### PR TITLE
Add .PHONY targets to Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ LDFLAGS += $(LDFLAGS_$(OS))
 # build rules
 ####
 
+.PHONY: all clean
+
 OBJECTS = $(SOURCES:.c=.o)
 
 all: lensed


### PR DESCRIPTION
This PR adds .PHONY tags to the Makefile for targets that don't correspond to files.
