### PR TITLE
GPU option added

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -3,6 +3,9 @@
 // options
 typedef struct
 {
+    // lensed
+    int gpu;
+    
     // data
     char* image;
     char* mask;

--- a/src/input/options.c
+++ b/src/input/options.c
@@ -50,6 +50,12 @@ DECLARE_TYPE(real)
 // list of known options
 struct option OPTIONS[] = {
     {
+        "gpu",
+        "Enable computations on GPU",
+        OPTION_OPTIONAL(bool, 1),
+        OPTION_FIELD(gpu)
+    },
+    {
         "image",
         "Input image, FITS file in counts/sec",
         OPTION_REQUIRED(string),

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -86,12 +86,9 @@ int main(int argc, char* argv[])
     verbose("kernel");
     
     {
-        // TODO decide the type of worker
-        int gpu = 1;
+        verbose("  device: %s", inp->opts->gpu ? "GPU" : "CPU");
         
-        verbose("  device: %s", gpu ? "GPU" : "CPU");
-        
-        err = clGetDeviceIDs(NULL, gpu ? CL_DEVICE_TYPE_GPU : CL_DEVICE_TYPE_CPU, 1, &device, NULL);
+        err = clGetDeviceIDs(NULL, inp->opts->gpu ? CL_DEVICE_TYPE_GPU : CL_DEVICE_TYPE_CPU, 1, &device, NULL);
         if(err != CL_SUCCESS)
             error("failed to get device");
         


### PR DESCRIPTION
Users can pass `--gpu=false` to lensed in order to disable GPU computations and run on the host. This is a lot slower though.
