### PR TITLE
Options are required depending on other options

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -165,9 +165,9 @@ input* read_input(int argc, char* argv[])
         }
     }
     
-    // make sure all required options are set
+    // make sure all required options are resolved
     for(size_t i = 0, n = noptions(); i < n; ++i)
-        if(inp->reqs[i])
+        if(!option_resolved(i, inp->opts, inp->reqs))
             error("missing required option: %s", option_name(i));
     
     // make sure that some objects are given

--- a/src/input.h
+++ b/src/input.h
@@ -5,6 +5,8 @@ typedef struct
 {
     // lensed
     int gpu;
+    int output;
+    char* root;
     
     // data
     char* image;
@@ -13,7 +15,6 @@ typedef struct
     double offset;
     
     // MultiNest
-    char* root;
     int nlive;
     int ins;
     int mmodal;
@@ -25,7 +26,6 @@ typedef struct
     int seed;
     int fb;
     int resume;
-    int outfile;
     int maxiter;
 } options;
 

--- a/src/input/options.h
+++ b/src/input/options.h
@@ -33,6 +33,9 @@ const char* option_help(size_t n);
 // return whether n'th option is required (true) or optional (false)
 int option_required(size_t n);
 
+// check whether option was not resolved
+int option_resolved(size_t n, options* opts, int reqs[]);
+
 // write default value of n'th option to buffer
 int option_default_value(char* buf, size_t buf_size, size_t n);
 

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -108,7 +108,7 @@ int main(int argc, char* argv[])
         main_program(inp->nobjs, inp->objs, &nkernels, &kernels);
         
         // output program
-        if(inp->opts->outfile)
+        if(inp->opts->output)
         {
             FILE* prg;
             char* prgname;
@@ -339,7 +339,8 @@ int main(int argc, char* argv[])
     int nclspar = ndim;
     double ztol = -1E90;
     char root[100] = {0};
-    strncpy(root, inp->opts->root, 99);
+    if(inp->opts->root)
+        strncpy(root, inp->opts->root, 99);
     int initmpi = 1;
     double logzero = -DBL_MAX;
     
@@ -350,7 +351,7 @@ int main(int argc, char* argv[])
     run(inp->opts->ins, inp->opts->mmodal, inp->opts->ceff, inp->opts->nlive,
         inp->opts->tol, inp->opts->eff, ndim, npar, nclspar,
         inp->opts->maxmodes, inp->opts->updint, ztol, root, inp->opts->seed,
-        wrap, inp->opts->fb, inp->opts->resume, inp->opts->outfile, initmpi,
+        wrap, inp->opts->fb, inp->opts->resume, inp->opts->output, initmpi,
         logzero, inp->opts->maxiter, loglike, dumper, &lensed);
     
     // take end time


### PR DESCRIPTION
This PR add the possibility to mark certain options as required only if other options (currently limited to type `bool`) are either set or not set. This is used to mark the `root` option as required only if `output` (was: `outfile`) is set to `true`.
