### PR TITLE
Dumper outputs images and saves results

### DIFF
--- a/kernel/lensed.cl
+++ b/kernel/lensed.cl
@@ -1,35 +1,67 @@
-kernel void lensed(constant char* data, constant int2* indices,
-    ulong nq, constant float2* aa, constant float* ww, constant float* ee,
-    constant float* mean, constant float* variance, global float* loglike)
+// integrate flux in pixel and return value and error estimate
+static float2 flux(constant char* data, int2 index,
+    ulong nq, constant float2* aa, constant float* ww, constant float* ee)
 {
-    // pixel index
-    size_t i = get_global_id(0);
-    
     // pixel position
-    float2 x = convert_float2(indices[i]);
+    float2 x = convert_float2(index);
     
     // surface brightness
-    float f;
+    float sb;
     
-    // value and error of pixel
-    float val = 0;
-    float err = 0;
+    // flux value and error of pixel
+    float2 flux = 0;
     
     // go through quadrature points
     for(size_t j = 0; j < nq; ++j)
     {
         // compute surface brightness at point
-        f = compute(data, x + aa[j]);
+        sb = compute(data, x + aa[j]);
         
         // add to value and error
-        val += ww[j]*f;
-        err += ee[j]*f;
+        flux.s0 += ww[j]*sb;
+        flux.s1 += ee[j]*sb;
     }
     
+    // done
+    return flux;
+}
+
+// compute image and calculate log-likelihood
+kernel void loglike(constant char* data, global const int2* indices,
+    ulong nq, constant float2* aa, constant float* ww, constant float* ee,
+    global const float* mean, global const float* variance,
+    global float* loglike)
+{
+    // get pixel index
+    size_t i = get_global_id(0);
+    
+    // integrate flux in pixel
+    float2 f = flux(data, indices[i], nq, aa, ww, ee);
+    
     // statistics
-    float d = val - mean[i];
-    float v = variance[i] + err*err;
+    float d = f.s0 - mean[i];
+    float v = variance[i] + f.s1*f.s1;
     
     // log-likelihood
     loglike[i] = -0.5f*(d*d/v + LOG_2PI + log(v));
+}
+
+// generate image and errors for dumper output
+kernel void dumper(constant char* data, global const int2* indices,
+    ulong nq, constant float2* aa, constant float* ww, constant float* ee,
+    global const float* mean, global const float* variance,
+    global float4* output)
+{
+    // get pixel index
+    size_t i = get_global_id(0);
+    
+    // integrate flux in pixel
+    float2 f = flux(data, indices[i], nq, aa, ww, ee);
+    
+    // statistics
+    float d = f.s0 - mean[i];
+    float v = variance[i] + f.s1*f.s1;
+    
+    // return flux, error, residual, chi^2
+    output[i] = (float4)(f, d, d*d/v);
 }

--- a/src/data.c
+++ b/src/data.c
@@ -206,23 +206,22 @@ data* read_data(const input* inp)
     return d;
 }
 
-void write_data(const char* filename, size_t width, size_t height,
-                size_t size, size_t num, cl_float* data[], cl_uint2 indices[])
+void write_output(const char* filename, const data* dat, size_t num, cl_float4* output)
 {
     double** images = malloc(num*sizeof(double*));
     
     for(size_t n = 0; n < num; ++n)
     {
         // allocate image filled with zeros
-        images[n] = calloc(width*height, sizeof(double));
+        images[n] = calloc(dat->width*dat->height, sizeof(double));
         
         // set pixels
-        for(size_t i = 0; i < size; ++i)
-            images[n][(indices[i].s[1]-1)*width+(indices[i].s[0]-1)] = data[n][i];
+        for(size_t i = 0; i < dat->size; ++i)
+            images[n][(dat->indices[i].s[1]-1)*dat->width+(dat->indices[i].s[0]-1)] = output[i].s[n];
     }
     
     // write FITS file
-    write_fits(filename, width, height, num, images);
+    write_fits(filename, dat->width, dat->height, num, images);
     
     for(size_t n = 0; n < num; ++n)
         free(images[n]);

--- a/src/data.h
+++ b/src/data.h
@@ -17,6 +17,5 @@ data* read_data(const input* inp);
 // free all memory allocated by data
 void free_data(data* dat);
 
-// write data to FITS file
-void write_data(const char* filename, size_t width, size_t height,
-                size_t size, size_t num, cl_float* data[], cl_uint2 indices[]);
+// write output to FITS file
+void write_output(const char* filename, const data* dat, size_t num, cl_float4* output);

--- a/src/lensed.h
+++ b/src/lensed.h
@@ -2,23 +2,30 @@
 
 struct lensed
 {
-    // parameter space
-    size_t npars;
-    prior** pris;
-    
-    // worker queue
-    cl_command_queue queue;
-    
-    // loglike arrays
-    size_t size;
-    size_t nd;
-    cl_mem indices;
-    cl_mem mean;
-    cl_mem variance;
-    cl_mem loglike;
+    // input data
+    data* dat;
     
     // global log-likelihood normalisation from gain
     double lognorm;
+    
+    // parameter space
+    size_t npars;
+    param** pars;
+    prior** pris;
+    
+    // results
+    const char* fits;
+    double logev;
+    double logev_err;
+    double logev_ins;
+    double max_loglike;
+    double* mean;
+    double* sigma;
+    double* ml;
+    double* map;
+    
+    // worker queue
+    cl_command_queue queue;
     
     // quadrature rule
     cl_mem qq;
@@ -27,8 +34,14 @@ struct lensed
     
     // main kernel
     cl_kernel kernel;
+    size_t nd;
+    cl_mem loglike;
     
     // parameter kernel
     cl_kernel set_params;
     cl_mem params;
+    
+    // dumper kernel
+    cl_kernel dumper;
+    cl_mem dumper_mem;
 };

--- a/src/nested.c
+++ b/src/nested.c
@@ -12,6 +12,7 @@
 
 #include "input.h"
 #include "prior.h"
+#include "data.h"
 #include "lensed.h"
 #include "nested.h"
 #include "constants.h"
@@ -32,7 +33,7 @@ void loglike(double cube[], int* ndim, int* npar, double* lnew, void* lensed_)
     cl_float* params = clEnqueueMapBuffer(lensed->queue, lensed->params, CL_TRUE, CL_MAP_WRITE, 0, lensed->npars*sizeof(cl_float), 0, NULL, NULL, &err);
     
     // copy parameters to device
-    for(int i = 0; i < lensed->npars; ++i)
+    for(size_t i = 0; i < lensed->npars; ++i)
         params[i] = cube[i];
     
     // done with parameter space
@@ -41,12 +42,16 @@ void loglike(double cube[], int* ndim, int* npar, double* lnew, void* lensed_)
     // set parameters
     err |= clEnqueueTask(lensed->queue, lensed->set_params, 0, NULL, NULL);
     
+    // check for errors
+    if(err != CL_SUCCESS)
+        error("failed to set parameters");
+    
     // run kernel
-    err |= clEnqueueNDRangeKernel(lensed->queue, lensed->kernel, 1, NULL, &lensed->nd, NULL, 0, NULL, NULL);
+    err = clEnqueueNDRangeKernel(lensed->queue, lensed->kernel, 1, NULL, &lensed->nd, NULL, 0, NULL, NULL);
     
     // check for errors
     if(err != CL_SUCCESS)
-        error("error running kernels");
+        error("failed to run kernel");
     
     // map result from device
     cl_float* loglike = clEnqueueMapBuffer(lensed->queue, lensed->loglike, CL_TRUE, CL_MAP_READ, 0, lensed->nd*sizeof(cl_float), 0, NULL, NULL, &err);
@@ -55,7 +60,7 @@ void loglike(double cube[], int* ndim, int* npar, double* lnew, void* lensed_)
     
     /* sum likelihood */
     double sum = 0.0;
-    for(int i = 0; i < lensed->size; ++i)
+    for(int i = 0; i < lensed->dat->size; ++i)
         sum += loglike[i] + lensed->lognorm;
     
     // unmap result
@@ -69,4 +74,63 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
             double** posterior, double** constraints, double* maxloglike,
             double* logz, double* inslogz, double* logzerr, void* lensed_)
 {
+    // result array indices
+    enum { MEAN, SIGMA, ML, MAP };
+    
+    struct lensed* lensed = lensed_;
+    
+    cl_int err;
+    cl_float4* output;
+    
+    // copy parameters to results
+    for(size_t i = 0; i < lensed->npars; ++i)
+        lensed->mean[i] = constraints[0][MEAN*lensed->npars+i];
+    for(size_t i = 0; i < lensed->npars; ++i)
+        lensed->sigma[i] = constraints[0][SIGMA*lensed->npars+i];
+    for(size_t i = 0; i < lensed->npars; ++i)
+        lensed->ml[i] = constraints[0][ML*lensed->npars+i];
+    for(size_t i = 0; i < lensed->npars; ++i)
+        lensed->map[i] = constraints[0][MAP*lensed->npars+i];
+    
+    // copy summary statistics
+    lensed->logev = *logz;
+    lensed->logev_err = *logzerr;
+    lensed->logev_ins = *inslogz;
+    lensed->max_loglike = *maxloglike;
+    
+    // map parameter space on device
+    cl_float* params = clEnqueueMapBuffer(lensed->queue, lensed->params, CL_TRUE, CL_MAP_WRITE, 0, lensed->npars*sizeof(cl_float), 0, NULL, NULL, &err);
+    
+    // copy ML parameters to device
+    for(size_t i = 0; i < lensed->npars; ++i)
+        params[i] = constraints[0][ML*lensed->npars+i];
+    
+    // done with parameter space
+    clEnqueueUnmapMemObject(lensed->queue, lensed->params, params, 0, NULL, NULL);
+    
+    // set parameters
+    err |= clEnqueueTask(lensed->queue, lensed->set_params, 0, NULL, NULL);
+    
+    // check for errors
+    if(err != CL_SUCCESS)
+        error("failed to set parameters");
+    
+    // run kernel
+    err = clEnqueueNDRangeKernel(lensed->queue, lensed->dumper, 1, NULL, &lensed->nd, NULL, 0, NULL, NULL);
+    
+    // check for errors
+    if(err != CL_SUCCESS)
+        error("failed to run dumper");
+    
+    // map output from device
+    output = clEnqueueMapBuffer(lensed->queue, lensed->dumper_mem, CL_TRUE, CL_MAP_READ, 0, lensed->nd*sizeof(cl_float4), 0, NULL, NULL, &err);
+    if(err != CL_SUCCESS)
+        error("failed to map dumper buffer");
+    
+    // output results if asked to
+    if(lensed->fits)
+        write_output(lensed->fits, lensed->dat, 4, output);
+    
+    // unmap buffers
+    clEnqueueUnmapMemObject(lensed->queue, lensed->dumper_mem, output, 0, NULL, NULL);
 }


### PR DESCRIPTION
This PR adds a lot of functionality regarding the results of the calculations. Firstly, the dumper can write a FITS file (if `output` is set) containing the image, integration error, residuals and chi^2 values. Secondly, the dumper now saves the numerical results of the computations, which are pretty-printed at the end of the run.
