### PR TITLE
Moved internal `errno`-related errors to `errori` function

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -1,6 +1,4 @@
 #include <stdlib.h>
-#include <string.h>
-#include <errno.h>
 
 #ifdef __APPLE__
 #include <OpenCL/opencl.h>
@@ -121,7 +119,7 @@ data* read_data(const input* inp)
     // try to allocate memory for data
     data* d = malloc(sizeof(data));
     if(!d)
-        error("could not create data: %s", strerror(errno));
+        errori("could not create data");
     
     // image and mask arrays
     double* image;

--- a/src/input.c
+++ b/src/input.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>
 
 #include "input.h"
 #include "input/objects.h"
@@ -94,7 +93,7 @@ input* read_input(int argc, char* argv[])
     // allocate memory for input
     input* inp = malloc(sizeof(input));
     if(!inp)
-        error("could not create input: %s", strerror(errno));
+        errori("could not create input");
     
     // create options
     inp->opts = create_options();

--- a/src/input/ini.c
+++ b/src/input/ini.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>
 
 #include "../input.h"
 #include "objects.h"
@@ -96,7 +95,7 @@ void read_ini(const char* ini, input* inp)
     // try to open file
     file = fopen(ini, "r");
     if(!file)
-        errorf(ini, 0, 0, "%s", strerror(errno));
+        errori(NULL);
     
     // start with first line
     line = 0;
@@ -217,7 +216,7 @@ void read_ini(const char* ini, input* inp)
     
     // check abort condition for errors
     if(ferror(file))
-        errorf(ini, line, "%s", strerror(errno));
+        errori(NULL);
     
     // close ini file
     fclose(file);

--- a/src/input/objects.c
+++ b/src/input/objects.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>
 
 #ifdef __APPLE__
 #include <OpenCL/opencl.h>
@@ -57,7 +56,7 @@ void add_object(input* inp, const char* id, const char* name)
     inp->nobjs += 1;
     inp->objs = realloc(inp->objs, inp->nobjs*sizeof(object));
     if(!inp->objs)
-        error("object %s: %s", name, strerror(errno));
+        errori("object %s", name);
     
     // realloc was successful, get new object
     obj = &inp->objs[inp->nobjs-1];
@@ -66,7 +65,7 @@ void add_object(input* inp, const char* id, const char* name)
     obj->id = malloc(strlen(id) + 1);
     obj->name = malloc(strlen(name) + 1);
     if(!obj->id || !obj->name)
-        error("object %s: %s", id, strerror(errno));
+        errori("object %s", id);
     strcpy((char*)obj->id, id);
     strcpy((char*)obj->name, name);
     
@@ -151,7 +150,7 @@ void add_object(input* inp, const char* id, const char* name)
     // array for kernel parameters
     params = malloc(obj->npars*sizeof(struct kernel_param));
     if(!params)
-        error("object %s: %s", strerror(errno));
+        errori("object %s", id);
     
     // get kernel parameters from buffer
     err = clEnqueueReadBuffer(queue, params_mem, CL_TRUE, 0, obj->npars*sizeof(struct kernel_param), params, 0, NULL, NULL);
@@ -161,7 +160,7 @@ void add_object(input* inp, const char* id, const char* name)
     // create array for params
     obj->pars = malloc(obj->npars*sizeof(param));
     if(!obj->pars)
-        error("object %s: %s", id, strerror(errno));
+        errori("object %s", id);
     
     // set up parameter array
     for(size_t i = 0; i < obj->npars; ++i)
@@ -250,7 +249,7 @@ void set_param_label(param* par, const char* label)
     // allocate space for string
     par->label = realloc((char*)par->label, strlen(label) + 1);
     if(!par->label)
-        error("could not set parameter label \"%s\": %s", label, strerror(errno));
+        errori("could not set parameter label \"%s\"", label);
     
     // copy label to param
     strcpy((char*)par->label, label);

--- a/src/input/options.c
+++ b/src/input/options.c
@@ -2,7 +2,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>
 
 #include "../input.h"
 #include "options.h"
@@ -171,7 +170,7 @@ options* create_options()
 {
     options* opts = malloc(sizeof(options));
     if(!opts)
-        error("%s", strerror(errno));
+        errori(NULL);
     memset(opts, 0, sizeof(options));
     return opts;
 }

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>
 #include <math.h>
 
 #include "input.h"
@@ -136,7 +135,7 @@ static const char* str_replace(const char* str, const char* search, const char* 
     // step 3: allocate buffer
     buf = malloc(buf_size);
     if(!buf)
-        error("%s", strerror(errno));
+        errori(NULL);
     
     // step 4: copy string and replace
     pos = in = str;
@@ -218,7 +217,7 @@ static const char* compute_kernel(size_t nobjs, object objs[])
     // allocate buffer
     buf = malloc(buf_size);
     if(!buf)
-        error("%s", strerror(errno));
+        errori(NULL);
     
     // start at beginning of data block
     d = 0;
@@ -232,13 +231,13 @@ static const char* compute_kernel(size_t nobjs, object objs[])
     // write file header
     wri = sprintf(out, FILEHEAD, "compute");
     if(wri < 0)
-        error("%s", strerror(errno));
+        errori(NULL);
     out += wri;
     
     // write header
     wri = sprintf(out, COMPHEAD);
     if(wri < 0)
-        error("%s", strerror(errno));
+        errori(NULL);
     out += wri;
     
     // write body
@@ -252,7 +251,7 @@ static const char* compute_kernel(size_t nobjs, object objs[])
             {
                 wri = sprintf(out, COMPDEFL);
                 if(wri < 0)
-                    error("%s", strerror(errno));
+                    errori(NULL);
                 out += wri;
             }
             
@@ -262,7 +261,7 @@ static const char* compute_kernel(size_t nobjs, object objs[])
             else
                 wri = sprintf(out, COMPSHED);
             if(wri < 0)
-                error("%s", strerror(errno));
+                errori(NULL);
             out += wri;
             
             // new type
@@ -275,7 +274,7 @@ static const char* compute_kernel(size_t nobjs, object objs[])
         else
             wri = sprintf(out, COMPSRCE, objs[i].name, d);
         if(wri < 0)
-            error("%s", strerror(errno));
+            errori(NULL);
         out += wri;
         
         // advance data pointer
@@ -285,13 +284,13 @@ static const char* compute_kernel(size_t nobjs, object objs[])
     // write footer
     wri = sprintf(out, COMPFOOT);
     if(wri < 0)
-        error("%s", strerror(errno));
+        errori(NULL);
     out += wri;
     
     // write file footer
     wri = sprintf(out, FILEFOOT);
     if(wri < 0)
-        error("%s", strerror(errno));
+        errori(NULL);
     out += wri;
     
     // this is our code
@@ -337,7 +336,7 @@ static const char* set_params_kernel(size_t nobjs, object objs[])
     // allocate buffer
     buf = malloc(buf_size);
     if(!buf)
-        error("%s", strerror(errno));
+        errori(NULL);
     
     // start at beginning of data and parameters
     p = d = 0;
@@ -348,13 +347,13 @@ static const char* set_params_kernel(size_t nobjs, object objs[])
     // write file header
     wri = sprintf(out, FILEHEAD, "set_params");
     if(wri < 0)
-        error("%s", strerror(errno));
+        errori(NULL);
     out += wri;
     
     // write header
     wri = sprintf(out, SETPHEAD);
     if(wri < 0)
-        error("%s", strerror(errno));
+        errori(NULL);
     out += wri;
     
     // write body
@@ -363,7 +362,7 @@ static const char* set_params_kernel(size_t nobjs, object objs[])
         // write left side of line
         wri = sprintf(out, SETPLEFT, objs[i].name, d);
         if(wri < 0)
-            error("%s", strerror(errno));
+            errori(NULL);
         out += wri;
         
         // write arguments
@@ -371,14 +370,14 @@ static const char* set_params_kernel(size_t nobjs, object objs[])
         {
             wri = sprintf(out, SETPARGS, p+j);
             if(wri < 0)
-                error("%s", strerror(errno));
+                errori(NULL);
             out += wri;
         }
         
         // write left side of line
         wri = sprintf(out, SETPRGHT);
         if(wri < 0)
-            error("%s", strerror(errno));
+            errori(NULL);
         out += wri;
         
         // increase offsets
@@ -389,13 +388,13 @@ static const char* set_params_kernel(size_t nobjs, object objs[])
     // write footer
     wri = sprintf(out, SETPFOOT);
     if(wri < 0)
-        error("%s", strerror(errno));
+        errori(NULL);
     out += wri;
     
     // write file footer
     wri = sprintf(out, FILEFOOT);
     if(wri < 0)
-        error("%s", strerror(errno));
+        errori(NULL);
     out += wri;
     
     // this is our code
@@ -441,7 +440,7 @@ static const char* load_kernel(const char* name)
     // try to allocate buffer
     buf = malloc(buf_size);
     if(!buf)
-        error("kernel %s: %s", name, strerror(errno));
+        errori("kernel %s", name);
     
     // start at beginning
     out = buf;
@@ -449,7 +448,7 @@ static const char* load_kernel(const char* name)
     // write file header
     wri = sprintf(out, FILEHEAD, name);
     if(wri < 0)
-        error("kernel %s: %s", name, strerror(errno));
+        errori("kernel %s", name);
     out += wri;
     
     // write file
@@ -460,7 +459,7 @@ static const char* load_kernel(const char* name)
     // write file footer
     wri = sprintf(out, FILEFOOT);
     if(wri < 0)
-        error("kernel %s: %s", name, strerror(errno));
+        errori("kernel %s", name);
     out += wri;
     
     // clean up

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -1,8 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
-#include <float.h>
 #include <string.h>
-#include <errno.h>
+#include <float.h>
 #include <math.h>
 #include <time.h>
 
@@ -99,7 +98,7 @@ int main(int argc, char* argv[])
     // get all parameters
     lensed.pars = malloc(lensed.npars*sizeof(param*));
     if(!lensed.pars)
-        error("%s", strerror(errno));
+        errori(NULL);
     for(size_t i = 0, p = 0; i < inp->nobjs; ++i)
         for(size_t j = 0; j < inp->objs[i].npars; ++j, ++p)
             lensed.pars[p] = &inp->objs[i].pars[j];
@@ -107,7 +106,7 @@ int main(int argc, char* argv[])
     // get all priors that will be needed when running
     lensed.pris = malloc(lensed.npars*sizeof(prior*));
     if(!lensed.pris)
-        error("%s", strerror(errno));
+        errori(NULL);
     for(size_t i = 0, p = 0; i < inp->nobjs; ++i)
         for(size_t j = 0; j < inp->objs[i].npars; ++j, ++p)
             lensed.pris[p] = inp->objs[i].pars[j].pri;
@@ -147,7 +146,7 @@ int main(int argc, char* argv[])
     lensed.ml = malloc(lensed.npars*sizeof(double));
     lensed.map = malloc(lensed.npars*sizeof(double));
     if(!lensed.mean || !lensed.sigma || !lensed.ml || !lensed.map)
-        error("%s", strerror(errno));
+        errori(NULL);
     
     
     /****************
@@ -181,25 +180,25 @@ int main(int argc, char* argv[])
         // output program
         if(inp->opts->output)
         {
-            FILE* prg;
-            char* prgname;
+            FILE* file;
+            char* name;
             
-            prgname = malloc(strlen(inp->opts->root) + strlen("kernel.cl") + 1);
-            if(!prgname)
-                error("%s", strerror(errno));
+            name = malloc(strlen(inp->opts->root) + strlen("kernel.cl") + 1);
+            if(!name)
+                errori(NULL);
             
-            strcpy(prgname, inp->opts->root);
-            strcat(prgname, "kernel.cl");
+            strcpy(name, inp->opts->root);
+            strcat(name, "kernel.cl");
             
-            prg = fopen(prgname, "w");
-            if(!prg)
-                error("could not write %s: %s", prgname, strerror(errno));
+            file = fopen(name, "w");
+            if(!file)
+                errori("could not write %s", name);
             
             for(size_t i = 0; i < nkernels; ++i)
-                fputs(kernels[i], prg);
+                fputs(kernels[i], file);
             
-            fclose(prg);
-            free(prgname);
+            fclose(file);
+            free(name);
         }
         
         // create program
@@ -463,9 +462,9 @@ int main(int argc, char* argv[])
     // summary statistics
     info("summary");
     info("  ");
-    info(LOG_BOLD "  evidence: " LOG_RESET "%.4f ± %.4f", inp->opts->ins ? lensed.logev_ins : lensed.logev, lensed.logev_err);
-    info(LOG_BOLD "  max ln p: " LOG_RESET "%.4f", lensed.max_loglike);
-    info(LOG_BOLD "  chi²/dof: " LOG_RESET "%.4f", chi2_dof);
+    info(LOG_BOLD "  log-evidence: " LOG_RESET "%.4f ± %.4f", inp->opts->ins ? lensed.logev_ins : lensed.logev, lensed.logev_err);
+    info(LOG_BOLD "  max log-like: " LOG_RESET "%.4f", lensed.max_loglike);
+    info(LOG_BOLD "  min chi²/dof: " LOG_RESET "%.4f", chi2_dof);
     info("  ");
     
     // parameter table
@@ -486,14 +485,14 @@ int main(int argc, char* argv[])
         
         name = malloc(strlen(inp->opts->root) + strlen(".paramnames") + 1);
         if(!name)
-            error("%s", strerror(errno));
+            errori(NULL);
         
         strcpy(name, inp->opts->root);
         strcat(name, ".paramnames");
         
         file = fopen(name, "w");
         if(!file)
-            error("could not write %s: %s", name, strerror(errno));
+            errori("could not write %s", name);
         
         for(size_t i = 0; i < inp->nobjs; ++i)
         {

--- a/src/log.c
+++ b/src/log.c
@@ -1,26 +1,28 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <string.h>
+#include <errno.h>
 
 #include "log.h"
 
-/* global log-level */
+// global log-level
 enum log_level LOG_LEVEL = LOG_INFO;
 
-/* set log level */
+// set log level
 void log_level(enum log_level log_level)
 {
     LOG_LEVEL = log_level;
 }
 
-/* log verbose */
+// log verbose
 void verbose(const char* msg, ...)
 {
     if(LOG_LEVEL <= LOG_VERBOSE)
     {
         va_list args;
         va_start(args, msg);
-
+        
         fprintf(stdout, LOG_DARK);
         vfprintf(stdout, msg, args);
         fprintf(stdout, LOG_RESET "\n");
@@ -29,7 +31,7 @@ void verbose(const char* msg, ...)
     }
 }
 
-/* log info */
+// log info
 void info(const char* msg, ...)
 {
     if(LOG_LEVEL <= LOG_INFO)
@@ -44,7 +46,7 @@ void info(const char* msg, ...)
     }
 }
 
-/* log warning */
+// log warning
 void warn(const char* msg, ...)
 {
     if(LOG_LEVEL <= LOG_WARN)
@@ -52,7 +54,7 @@ void warn(const char* msg, ...)
         va_list args;
         va_start(args, msg);
         
-        fprintf(stderr, "WARNING: ");
+        fprintf(stderr, LOG_BOLD "warning: " LOG_RESET);
         vfprintf(stderr, msg, args);
         fprintf(stderr, "\n");
         
@@ -66,7 +68,7 @@ void warn(const char* msg, ...)
     }
 }
 
-/* log error and exit */
+// log error and exit
 void error(const char* msg, ...)
 {
     if(LOG_LEVEL <= LOG_ERROR)
@@ -74,7 +76,7 @@ void error(const char* msg, ...)
         va_list args;
         va_start(args, msg);
         
-        fprintf(stderr, "ERROR: ");
+        fprintf(stderr, LOG_BOLD "error: " LOG_RESET);
         vfprintf(stderr, msg, args);
         fprintf(stderr, "\n");
         
@@ -84,7 +86,7 @@ void error(const char* msg, ...)
     exit(EXIT_FAILURE);
 }
 
-/* log file error and exit */
+// log file error and exit
 void errorf(const char* file, size_t line, const char* msg, ...)
 {
     if(LOG_LEVEL <= LOG_ERROR)
@@ -97,11 +99,34 @@ void errorf(const char* file, size_t line, const char* msg, ...)
         va_list args;
         va_start(args, msg);
         
-        fprintf(stderr, "ERROR: ");
+        fprintf(stderr, LOG_BOLD "error: " LOG_RESET);
         vfprintf(stderr, msg, args);
         fprintf(stderr, "\n");
         
         va_end(args);
+    }
+    
+    exit(EXIT_FAILURE);
+}
+
+// log internal error and exit
+void errori(const char* msg, ...)
+{
+    if(LOG_LEVEL <= LOG_ERROR)
+    {
+        fprintf(stderr, LOG_BOLD "error: " LOG_RESET);
+        
+        if(msg)
+        {
+            va_list args;
+            va_start(args, msg);
+            vfprintf(stderr, msg, args);
+            fprintf(stderr, ": ");
+            va_end(args);
+        }
+        
+        fprintf(stderr, "%s", strerror(errno));
+        fprintf(stderr, "\n");
     }
     
     exit(EXIT_FAILURE);

--- a/src/log.h
+++ b/src/log.h
@@ -28,6 +28,9 @@ void error(const char* msg, ...);
 // print an error message in a file and exit
 void errorf(const char* file, size_t line, const char* msg, ...);
 
+// print an internal error message and exit
+void errori(const char* msg, ...);
+
 // some output codes for Unix-like terminals
 #define LOG_BOLD "\033[1m"
 #define LOG_DARK "\033[2m"

--- a/src/prior.c
+++ b/src/prior.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 
 #include "input.h"
 #include "prior.h"
@@ -74,7 +73,7 @@ prior* read_prior(const char* str)
     // allocate array for arguments
     args = malloc(nargs*sizeof(const char*));
     if(!args)
-        error("%s", strerror(errno));
+        errori(NULL);
     
     // tokenize string into arguments
     nargs = 0;
@@ -84,7 +83,7 @@ prior* read_prior(const char* str)
         spn = strcspn(str + pos, WS);
         arg = malloc(spn + 1);
         if(!arg)
-            error("%s", strerror(errno));
+            errori(NULL);
         strncpy(arg, str + pos, spn);
         arg[spn] = '\0';
         
@@ -106,7 +105,7 @@ prior* read_prior(const char* str)
     // create prior
     pri = malloc(sizeof(prior));
     if(!pri)
-        error("%s", strerror(errno));
+        errori(NULL);
     
     // set up prior functions
     pri->prior = PRIORS[pos].prior;

--- a/src/prior/unif.c
+++ b/src/prior/unif.c
@@ -1,7 +1,5 @@
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
-#include <errno.h>
 
 #include "unif.h"
 #include "../parse.h"
@@ -32,7 +30,7 @@ void* read_prior_unif(size_t nargs, const char* argv[])
     
     unif = malloc(sizeof(struct uniform));
     if(!unif)
-        error("%s", strerror(errno));
+        errori(NULL);
     
     unif->a = a;
     unif->b = b;


### PR DESCRIPTION
There is a new error log function `errori` that outputs an error string for an internal error (using `errno`).

The usage is as follows:

``` c
errori(NULL) = error("%s", strerror(errno));
errori(fmt, ...) = error("%s: %s", fmt, strerror(errno));
```

Error messages also have a better style now.
