### PR TITLE
Parameter `id` field

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -209,10 +209,7 @@ void print_input(const input* inp)
                 char buf[100] = {0};
                 print_prior(inp->objs[i].pars[j].pri, buf, 99);
                 
-                if(inp->objs[i].pars[j].label)
-                    verbose("  %zu: %s ~ %s", p, inp->objs[i].pars[j].label, buf);
-                else
-                    verbose("  %zu: %s.%s ~ %s", p, inp->objs[i].name, inp->objs[i].pars[j].name, buf);
+                verbose("  %zu: %s ~ %s", p, inp->objs[i].pars[j].label ? inp->objs[i].pars[j].label : inp->objs[i].pars[j].id, buf);
             }
         }
     }

--- a/src/input.h
+++ b/src/input.h
@@ -35,8 +35,11 @@ typedef struct prior prior;
 // parameters for objects
 typedef struct
 {
-    // name of parameter, used as identifier
+    // name of parameter
     char name[32];
+    
+    // identifier of parameter
+    const char* id;
     
     // label, used for output
     const char* label;

--- a/src/input/objects.c
+++ b/src/input/objects.c
@@ -165,9 +165,19 @@ void add_object(input* inp, const char* id, const char* name)
     // set up parameter array
     for(size_t i = 0; i < obj->npars; ++i)
     {
+        // id of parameter
+        char* id;
+        
         // copy name into param
         for(size_t j = 0; j <= sizeof(params[i].name); ++j)
             obj->pars[i].name[j] = params[i].name[j];
+        
+        // create id
+        id = malloc(strlen(obj->id) + 1 + strlen(obj->pars[i].name) + 1);
+        if(!id)
+            errori(NULL);
+        sprintf(id, "%s.%s", obj->id, obj->pars[i].name);
+        obj->pars[i].id = id;
         
         // no label is set
         obj->pars[i].label = NULL;
@@ -240,6 +250,7 @@ param* find_param(object* obj, const char* name)
 
 void free_param(param* par)
 {
+    free((char*)par->id);
     free((char*)par->label);
     free_prior(par->pri);
 }

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -473,8 +473,7 @@ int main(int argc, char* argv[])
     info(LOG_BOLD "  %-10s  %10s  %10s  %10s  %10s" LOG_RESET, "parameter", "mean", "sigma", "ML", "MAP");
     info("  ----------------------------------------------------------");
     for(size_t i = 0; i < lensed.npars; ++i)
-        if(lensed.pars[i]->label)
-            info("  %-10s  %10.4f  %10.4f  %10.4f  %10.4f", lensed.pars[i]->label, lensed.mean[i], lensed.sigma[i], lensed.ml[i], lensed.map[i]);
+        info("  %-10s  %10.4f  %10.4f  %10.4f  %10.4f", lensed.pars[i]->label ? lensed.pars[i]->label : lensed.pars[i]->id, lensed.mean[i], lensed.sigma[i], lensed.ml[i], lensed.map[i]);
     info("  ");
     
     // write parameter names and labels to file
@@ -495,16 +494,8 @@ int main(int argc, char* argv[])
             errori("could not write %s", name);
         
         for(size_t i = 0; i < inp->nobjs; ++i)
-        {
             for(size_t j = 0; j < inp->objs[i].npars; ++j)
-            {
-                int width = fprintf(file, "%s.%s", inp->objs[i].name, inp->objs[i].pars[j].name);
-                fprintf(file, "%*s", width < 20 ? 20 - width : 0, " ");
-                if(inp->objs[i].pars[j].label)
-                    fprintf(file, "%s", inp->objs[i].pars[j].label);
-                fprintf(file, "\n");
-            }
-        }
+                fprintf(file, "%-20s  %s\n", inp->objs[i].pars[j].id, inp->objs[i].pars[j].label ? inp->objs[i].pars[j].label : "");
         
         fclose(file);
         free(name);


### PR DESCRIPTION
This PR adds an `id` field to the parameter struct. This is a string of the form `<object>.<param>` (e.g. `lens.x`) which can be used instead of a label when the latter is not present.
