### PR TITLE
Batch output mode

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -7,6 +7,7 @@ typedef struct
     int gpu;
     int output;
     char* root;
+    int batch_header;
     
     // data
     char* image;
@@ -24,7 +25,6 @@ typedef struct
     int maxmodes;
     int updint;
     int seed;
-    int fb;
     int resume;
     int maxiter;
 } options;

--- a/src/input/options.c
+++ b/src/input/options.c
@@ -141,12 +141,6 @@ struct option OPTIONS[] = {
         OPTION_FIELD(seed)
     },
     {
-        "fb",
-        "Show MultiNest feedback",
-        OPTION_OPTIONAL(bool, 0),
-        OPTION_FIELD(fb)
-    },
-    {
         "resume",
         "Resume from last checkpoint",
         OPTION_OPTIONAL(bool, 0),

--- a/src/log.h
+++ b/src/log.h
@@ -1,10 +1,11 @@
 #pragma once
 
-/* the diverse levels of logging */
+// the individual levels of logging
 extern enum log_level
 {
     LOG_VERBOSE,
     LOG_INFO,
+    LOG_BATCH,
     LOG_WARN,
     LOG_ERROR,
     LOG_QUIET


### PR DESCRIPTION
This PR adds a batch output mode "--batch" to lensed. When doing batch output, a single line is written to stdout at the end of the run, containing all results (summary and parameters for mean, sigma, ML, MAP). A header row for easier parsing of the output can be printed using `lensed --batch-header`.

In order to suppress additional output, this PR also introduces stdout redirection for MultiNest. If output is enabled, a log with the feedback is written to `<root>log.txt`. If output is not enabled, the log is written to the null device instead. Verbose output mode sets MultiNest's `feedback` flag to produce step-by-step feedback in the log.
