### PR TITLE
Fixed memory leak when redefining a prior

### DIFF
--- a/src/input/objects.c
+++ b/src/input/objects.c
@@ -268,6 +268,9 @@ void set_param_label(param* par, const char* label)
 
 void set_param_prior(param* par, const char* str)
 {
+    // free existing prior
+    free_prior(par->pri);
+    
     // parse prior
     par->pri = read_prior(str);
 }

--- a/src/prior.c
+++ b/src/prior.c
@@ -128,8 +128,11 @@ prior* read_prior(const char* str)
 
 void free_prior(prior* pri)
 {
-    pri->free(pri->data);
-    free(pri);
+    if(pri)
+    {
+        pri->free(pri->data);
+        free(pri);
+    }
 }
 
 void print_prior(const prior* pri, char* buf, size_t n)


### PR DESCRIPTION
Old prior was not freed before new prior was assigned.
