### PR TITLE
Flat-field handling

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -19,3 +19,6 @@ void free_data(data* dat);
 
 // write output to FITS file
 void write_output(const char* filename, const data* dat, size_t num, cl_float4* output);
+
+// find mode (i.e. most common value) of input data
+double find_mode(size_t nvalues, cl_float values[]);

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -61,6 +61,9 @@ int main(int argc, char* argv[])
     // program data
     struct lensed lensed;
     
+    // statistics for checking data
+    double data_mode;
+    
     // OpenCL error code
     cl_int err;
     
@@ -180,6 +183,17 @@ int main(int argc, char* argv[])
     
     // set global log-likelihood normalisation
     lensed.lognorm = -log(inp->opts->gain);
+    
+    // get mode of data
+    data_mode = find_mode(lensed.dat->size, lensed.dat->mean);
+    
+    // make sure that data is flat-fielded
+    if(fabs(data_mode) > DBL_EPSILON)
+        warn("mode of data is not zero (mode = %f)\n"
+             "The most common value in the data is different from zero. This "
+             "might indicate that your image was not flat-field corrected or "
+             "that there is not much empty sky in the field of view. In both "
+             "cases the reconstruction will probably fail.", data_mode);
     
     
     /***********


### PR DESCRIPTION
Right now, lensed expects the data to be perfectly flat-field corrected. This works for our mock data, but we need something more sophisticated for real observations.

I think the best approach is to have a background sky as in galfit (see the [instructions](http://users.obs.carnegiescience.edu/peng/work/galfit/README.pdf)). This constant offset in counts/sec can be a free parameter, given a prior and recovered together with the rest of the parameters.

In any case, we need a bunch of statistical checks to verify that the input makes sense. This PR at the moment contains a crude check that the mode of the data is zero.
