### PR TITLE
Simplified data handling with optional weight map

### DIFF
--- a/kernel/lensed.cl
+++ b/kernel/lensed.cl
@@ -15,7 +15,7 @@ static float2 flux(constant char* data, float2 x,
 
 // compute image and calculate log-likelihood
 kernel void loglike(constant char* data, constant float2* qq, constant float2* ww,
-    global const float* mean, global const float* variance, global float* loglike)
+    global const float* image, global const float* weight, global float* output)
 {
     // get pixel index
     size_t i = get_global_id(0);
@@ -29,18 +29,15 @@ kernel void loglike(constant char* data, constant float2* qq, constant float2* w
         // integrate flux in pixel
         float2 f = flux(data, x, qq, ww);
         
-        // statistics
-        float d = f.s0 - mean[i];
-        float v = variance[i] + f.s1*f.s1;
-        
-        // log-likelihood
-        loglike[i] = -0.5f*(d*d/v + LOG_2PI + log(v));
+        // chi^2 value for pixel
+        float d = f.s0 - image[i];
+        output[i] = weight[i]*d*d;
     }
 }
 
 // generate image and errors for dumper output
 kernel void dumper(constant char* data, constant float2* qq, constant float2* ww,
-    global const float* mean, global const float* variance, global float4* output)
+    global const float* image, global const float* weight, global float4* output)
 {
     // get pixel index
     size_t i = get_global_id(0);
@@ -54,11 +51,8 @@ kernel void dumper(constant char* data, constant float2* qq, constant float2* ww
         // integrate flux in pixel
         float2 f = flux(data, x, qq, ww);
         
-        // statistics
-        float d = f.s0 - mean[i];
-        float v = variance[i] + f.s1*f.s1;
-        
         // return flux, error, residual, chi^2
-        output[i] = (float4)(f, d, d*d/v);
+        float d = f.s0 - image[i];
+        output[i] = (float4)(f, d, weight[i]*d*d);
     }
 }

--- a/src/data.c
+++ b/src/data.c
@@ -18,55 +18,57 @@ void fits_error(const char* filename, int status)
     
     fits_get_errstatus(status, err_text);
     
-    error("\"%s\": %s", filename, err_text);
+    errorf(filename, 0, "%s", err_text);
 }
 
-void read_fits(const char* filename, size_t* width, size_t* height, double** image)
+void read_fits(const char* filename, int datatype, size_t* width, size_t* height, void** image)
 {
     int status = 0;
     
-    /* the FITS file */
+    // the FITS file
     fitsfile* fptr;
     
-    /* metadata */
+    // metadata
     int bitpix;
     int naxis;
     long naxes[2];
     
-    /* total number of pixels */
+    // total number of pixels
     long npix;
     
-    /* reading offset */
+    // reading offset
     long fpixel[2] = { 1, 1 };
     
-    /* open FITS file */
+    // open FITS file
     fits_open_image(&fptr, filename, READONLY, &status);
     if(status)
         fits_error(filename, status);
     
-    /* get metadata */
+    // get metadata
     fits_get_img_param(fptr, 2, &bitpix, &naxis, naxes, &status);
     if(status)
         fits_error(filename, status);
     
-    /* check dimension of image */
+    // check dimension of image
     if(naxis != 2)
-        error("file \"%s\" has %d instead of 2 axes", filename, naxis);
+        errorf(filename, 0, "file has %d axes (should be 2)", naxis);
     
-    /* set dimensions */
+    // set dimensions
     *width = naxes[0];
     *height = naxes[1];
     
-    /* create array for pixels */
+    // create array for pixels
     npix = naxes[0]*naxes[1];
     *image = malloc(npix*sizeof(double));
+    if(!*image)
+        errori(NULL);
     
-    /* read pixels */
-    fits_read_pix(fptr, TDOUBLE, fpixel, npix, NULL, *image, NULL, &status);
+    // read pixels into array
+    fits_read_pix(fptr, datatype, fpixel, npix, NULL, *image, NULL, &status);
     if(status)
         fits_error(filename, status);
     
-    /* close file again */
+    // close file again
     fits_close_file(fptr, &status);
     if(status)
         fits_error(filename, status);
@@ -87,126 +89,107 @@ void write_fits(const char* filename, size_t width, size_t height,
     int naxis = 2;
     long naxes[2] = { width, height };
     
-    /* reading offset */
+    // writing offset
     long fpixel[2] = { 1, 1 };
     
-    /* create FITS file */
+    // create FITS file
     fits_create_file(&fptr, filename, &status);
     if(status)
         fits_error(filename, status);
     
     for(size_t n = 0; n < num; ++n)
     {
-        /* create image extension */
+        // create image extension
         fits_create_img(fptr, DOUBLE_IMG, naxis, naxes, &status);
         if(status)
             fits_error(filename, status);
         
-        /* write pixels */
+        // write pixels
         fits_write_pix(fptr, TDOUBLE, fpixel, npix, images[n], &status);
         if(status)
             fits_error(filename, status);
     }
     
-    /* close file */
+    // close file
     fits_close_file(fptr, &status);
     if(status)
         fits_error(filename, status);
 }
 
-data* read_data(const input* inp)
+void read_image(const char* filename, size_t* width, size_t* height, cl_float** image)
 {
-    // try to allocate memory for data
-    data* d = malloc(sizeof(data));
-    if(!d)
-        errori("could not create data");
+    // read FITS file
+    read_fits(filename, TFLOAT, width, height, (void**)image);
     
-    // image and mask arrays
-    double* image;
-    size_t mx, my;
-    double* mask;
-    
-    /* read image */
-    read_fits(inp->opts->image, &d->width, &d->height, &image);
-    
-    /* total number of pixels */
-    d->size = d->width*d->height;
-    
-    /* use mask if given */
-    if(inp->opts->mask)
-    {
-        /* read mask */
-        read_fits(inp->opts->mask, &mx, &my, &mask);
-        
-        /* make sure mask and image dimensions match if given */
-        if(mask && (mx != d->width || my != d->height))
-            error("mask dimensions %zux%zu should match image dimensions %zux%zu", mx, my, d->width, d->height);
-        
-        // count masked pixels
-        d->nmask = 0;
-        for(size_t i = 0; i < d->size; ++i)
-            if(mask[i])
-                d->nmask += 1;
-    }
-    else
-    {
-        // zero mask
-        mask = calloc(d->size, sizeof(cl_int));
-        d->nmask = 0;
-    }
-    
-    /* allocate arrays for data */
-    d->mean = malloc(d->size*sizeof(cl_float));
-    d->variance = malloc(d->size*sizeof(cl_float));
-    d->mask = malloc(d->size*sizeof(cl_int));
-    
-    /* set data pixels */
-    for(size_t i = 0; i < d->size; ++i)
-    {
-        /* mean value */
-        d->mean[i] = image[i];
-        
-        /* variance */
-        d->variance[i] = (image[i] + inp->opts->offset)/inp->opts->gain;
-        
-        /* mask */
-        d->mask[i] = mask[i];
-    }
-    
-    /* free image and mask arrays */
-    free(image);
-    free(mask);
-    
-    // done
-    return d;
+    // TODO process depending on format
 }
 
-void write_output(const char* filename, const data* dat, size_t num, cl_float4* output)
+void read_weight(const char* filename, size_t width, size_t height, cl_float** weight)
 {
+    // weight width and height
+    size_t wht_w, wht_h;
+    
+    // read weights from FITS file
+    read_fits(filename, TFLOAT, &wht_w, &wht_h, (void**)weight);
+    
+    // make sure dimensions agree
+    if(wht_w != width || wht_h != height)
+        errorf(filename, 0, "wrong dimensions %zu x %zu for weights (should be %zu x %zu)", wht_w, wht_h, width, height);
+    
+    // TODO process depending on format
+}
+
+void make_weight(const cl_float* image, size_t width, size_t height, double gain, double offset, cl_float** weight)
+{
+    // total size of weights
+    size_t size = width*height;
+    
+    // make array for weights
+    cl_float* w = malloc(size*sizeof(cl_float));
+    if(!w)
+        errori(NULL);
+    
+    // calculate inverse variance for each pixel
+    for(size_t i = 0; i < size; ++i)
+        w[i] = gain/(image[i] + offset);
+    
+    // output weights
+    *weight = w;
+}
+
+void read_mask(const char* filename, size_t width, size_t height, int** mask)
+{
+    // mask width and height
+    size_t msk_w, msk_h;
+    
+    // read mask from FITS file
+    read_fits(filename, TINT, &msk_w, &msk_h, (void**)mask);
+    
+    // make sure dimensions agree
+    if(msk_w != width || msk_h != height)
+        errorf(filename, 0, "wrong dimensions %zu x %zu for mask (should be %zu x %zu)", msk_w, msk_h, width, height);
+}
+
+void write_output(const char* filename, size_t width, size_t height, size_t num, cl_float4* output)
+{
+    size_t size = width*height;
+    
     double** images = malloc(num*sizeof(double*));
     
     for(size_t n = 0; n < num; ++n)
     {
         // allocate image filled with zeros
-        images[n] = calloc(dat->width*dat->height, sizeof(double));
+        images[n] = calloc(size, sizeof(double));
         
         // set pixels
-        for(size_t i = 0; i < dat->size; ++i)
+        for(size_t i = 0; i < size; ++i)
             images[n][i] = output[i].s[n];
     }
     
     // write FITS file
-    write_fits(filename, dat->width, dat->height, num, images);
+    write_fits(filename, width, height, num, images);
     
     for(size_t n = 0; n < num; ++n)
         free(images[n]);
     free(images);
-}
-
-void free_data(data* d)
-{
-    free(d->mean);
-    free(d->variance);
-    free(d->mask);
-    free(d);
 }

--- a/src/data.h
+++ b/src/data.h
@@ -1,22 +1,16 @@
 #pragma once
 
-typedef struct
-{
-    size_t width;
-    size_t height;
-    size_t size;
-    cl_float* mean;
-    cl_float* variance;
-    size_t nmask;
-    cl_int* mask;
-    double lognorm;
-} data;
+// read image from file
+void read_image(const char* filename, size_t* width, size_t* height, cl_float** image);
 
-// read image from file, with optional mask
-data* read_data(const input* inp);
+// read weights from file
+void read_weight(const char* filename, size_t width, size_t height, cl_float** weight);
 
-// free all memory allocated by data
-void free_data(data* dat);
+// generate weights from image
+void make_weight(const cl_float* image, size_t width, size_t height, double gain, double offset, cl_float** weight);
+
+// read mask from file
+void read_mask(const char* filename, size_t width, size_t height, int** mask);
 
 // write output to FITS file
-void write_output(const char* filename, const data* dat, size_t num, cl_float4* output);
+void write_output(const char* filename, size_t width, size_t height, size_t num, cl_float4* output);

--- a/src/input.h
+++ b/src/input.h
@@ -11,6 +11,7 @@ typedef struct
     
     // data
     char* image;
+    char* weight;
     char* mask;
     double gain;
     double offset;

--- a/src/input/options.c
+++ b/src/input/options.c
@@ -71,14 +71,20 @@ struct option OPTIONS[] = {
     {
         "gain",
         "Conversion factor to counts",
-        OPTION_REQUIRED(real),
+        OPTION_REQIFNOT(real, 1, weight),
         OPTION_FIELD(gain)
     },
     {
         "offset",
         "Subtracted flat-field offset",
-        OPTION_REQUIRED(real),
+        OPTION_REQIFNOT(real, 0, weight),
         OPTION_FIELD(offset)
+    },
+    {
+        "weight",
+        "Weight map in 1/(counts/sec)^2",
+        OPTION_OPTIONAL(string, NULL),
+        OPTION_FIELD(weight)
     },
     {
         "mask",
@@ -172,6 +178,7 @@ options* create_options()
 void free_options(options* opts)
 {
     free(opts->image);
+    free(opts->weight);
     free(opts->mask);
     free(opts->root);
     free(opts);

--- a/src/lensed.h
+++ b/src/lensed.h
@@ -3,10 +3,11 @@
 struct lensed
 {
     // input data
-    data* dat;
-    
-    // global log-likelihood normalisation from gain
-    double lognorm;
+    size_t width;
+    size_t height;
+    size_t size;
+    cl_float* image;
+    cl_float* weight;
     
     // parameter space
     size_t npars;
@@ -32,7 +33,7 @@ struct lensed
     
     // main kernel
     cl_kernel kernel;
-    cl_mem loglike;
+    cl_mem output_mem;
     
     // parameter kernel
     cl_kernel set_params;


### PR DESCRIPTION
This PR simplifies how data is handled internally and prepares the code for various data formats as discussed in issue #62.

It also introduces the change proposed in #70 to the calculation of the likelihood, thereby significantly simplifying the calculation. Since the variance is fixed for each pixel, we can ignore the normalisation constant of the likelihood, so that the latter subsequently reduces to a simple `log L = -0.5 \sum \chi^2` likelihood.
