### PR TITLE
Output numerical constants

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>
+#include <math.h>
 
 #include "parse.h"
 #include "constants.h"
@@ -81,6 +82,32 @@ int read_real(double* out, const char* in)
 
 int write_real(char* out, const double* in, size_t n)
 {
+    size_t i;
+    
+    if(*in == 0)
+    {
+        snprintf(out, n, "0");
+        return 0;
+    }
+    
+    for(i = 0; i < NREAL_CONSTS; ++i)
+    {
+        double f = (*in)/REAL_CONSTS[i].value;
+        
+        if(f == 1.0)
+        {
+            snprintf(out, n, "%s", REAL_CONSTS[i].name);
+            return 0;
+        }
+        
+        if(100*f == floor(100*f))
+        {
+            snprintf(out, n, "%g%s", f, REAL_CONSTS[i].name);
+            return 0;
+        }
+    }
+    
     snprintf(out, n, "%g", *in);
+    
     return 0;
 }

--- a/src/prior/unif.c
+++ b/src/prior/unif.c
@@ -1,5 +1,5 @@
 #include <stdlib.h>
-#include <stdio.h>
+#include <string.h>
 
 #include "unif.h"
 #include "../parse.h"
@@ -47,7 +47,22 @@ void print_prior_unif(const void* data, char* buf, size_t n)
 {
     const struct uniform* unif = data;
     
-    snprintf(buf, n, "U(%g, %g)", unif->a, unif->b);
+    size_t len = 0;
+    if(len + 2 > n)
+        return;
+    strcpy(buf, "U(");
+    len += 2;
+    write_real(buf + len, &unif->a, n - len);
+    len = strlen(buf);
+    if(len + 2 > n)
+        return;
+    strcat(buf, ", ");
+    len += 2;
+    write_real(buf + len, &unif->b, n - len);
+    len = strlen(buf);
+    if(len + 2 > n)
+        return;
+    strcat(buf, ")");
 }
 
 double prior_unif(const void* data, double u)


### PR DESCRIPTION
We can already use numerical constants such as `2pi` for input. Now they are printed back in the same way:

```
\theta_L ~ U(0, pi)
```
