### PR TITLE
Warn if background is zero but no offset was given

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -16,4 +16,4 @@ void read_mask(const char* filename, size_t width, size_t height, int** mask);
 void write_output(const char* filename, size_t width, size_t height, size_t num, cl_float4* output);
 
 // find most common value
-cl_float find_mode(size_t nvalues, const cl_float values[], const cl_float mask[]);
+void find_mode(size_t nvalues, const cl_float values[], const cl_float mask[], double* mode, double* fwhm);


### PR DESCRIPTION
This PR adds a warning if the image appears to be flat-field corrected but no offset for this correction was provided.

The `find_mode()` function now returns the FWHM of the mode, which is used to determine how close the mode is to zero.
