### PR TITLE
Attributes to fix GitHub language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+src/*       linguist-language=C
+kernel/*    linguist-language=OpenCL


### PR DESCRIPTION
This should remove all the variants of C being detected on GitHub.
