### PR TITLE
Make sure no second lensing plane is created

### DIFF
--- a/src/input/ini.c
+++ b/src/input/ini.c
@@ -119,6 +119,8 @@ void read_ini(const char* ini, input* inp)
     object* obj;
     param* par;
     int grp;
+    int typ;
+    size_t nplanes;
     int err;
     
     // try to open file
@@ -135,6 +137,10 @@ void read_ini(const char* ini, input* inp)
     
     // initial group is "options"
     grp = GRP_OPTIONS;
+    
+    // no planes, start without type
+    typ = 0;
+    nplanes = 0;
     
     // read file line by line
     while(fgets(buf, sizeof(buf), file))
@@ -235,6 +241,20 @@ void read_ini(const char* ini, input* inp)
             if(obj)
                 errorf(ini, line, "duplicate object name: %s", name);
             add_object(inp, name, value);
+            
+            // TODO take this out once multiple planes work
+            obj = find_object(inp, name);
+            if(obj->type != typ && obj->type != OBJ_FOREGROUND)
+            {
+                if(obj->type == OBJ_LENS)
+                {
+                    nplanes += 1;
+                    if(nplanes > 1)
+                        errorf(ini, line, "multiple lensing planes are not supported");
+                }
+                typ = obj->type;
+            }
+            
             break;
             
         case GRP_PRIORS:


### PR DESCRIPTION
This PR will give an error if the user tries to create multiple lensing planes. This is necessary until #3 is implemented.
