### PR TITLE
Read per-pixel effective gain from FITS file

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -138,6 +138,39 @@ void read_image(const char* filename, size_t* width, size_t* height, cl_float** 
     // TODO process depending on format
 }
 
+void read_gain(const char* filename, size_t width, size_t height, double** gain)
+{
+    // gain width and height
+    size_t gw, gh;
+    
+    // read gain from FITS file
+    read_fits(filename, TDOUBLE, &gw, &gh, (void**)gain);
+    
+    // make sure dimensions agree
+    if(gw != width || gh != height)
+        errorf(filename, 0, "wrong dimensions %zu x %zu for gain (should be %zu x %zu)", gw, gh, width, height);
+    
+    // TODO process depending on format
+}
+
+void make_gain(double value, size_t width, size_t height, double** gain)
+{
+    // total size of gain
+    size_t size = width*height;
+    
+    // make array for gain
+    double* g = malloc(size*sizeof(double));
+    if(!g)
+        errori(NULL);
+    
+    // set uniform gain for each pixel
+    for(size_t i = 0; i < size; ++i)
+        g[i] = value;
+    
+    // output gain
+    *gain = g;
+}
+
 void read_weight(const char* filename, size_t width, size_t height, cl_float** weight)
 {
     // weight width and height
@@ -153,7 +186,7 @@ void read_weight(const char* filename, size_t width, size_t height, cl_float** w
     // TODO process depending on format
 }
 
-void make_weight(const cl_float* image, size_t width, size_t height, double gain, double offset, cl_float** weight)
+void make_weight(const cl_float* image, const double* gain, double offset, size_t width, size_t height, cl_float** weight)
 {
     // total size of weights
     size_t size = width*height;
@@ -165,7 +198,7 @@ void make_weight(const cl_float* image, size_t width, size_t height, double gain
     
     // calculate inverse variance for each pixel
     for(size_t i = 0; i < size; ++i)
-        w[i] = gain/(image[i] + offset);
+        w[i] = gain[i]/(image[i] + offset);
     
     // output weights
     *weight = w;

--- a/src/data.h
+++ b/src/data.h
@@ -3,11 +3,17 @@
 // read image from file
 void read_image(const char* filename, size_t* width, size_t* height, cl_float** image);
 
+// read gain from file
+void read_gain(const char* filename, size_t width, size_t height, double** gain);
+
+// uniform gain
+void make_gain(double value, size_t width, size_t height, double** gain);
+
 // read weights from file
 void read_weight(const char* filename, size_t width, size_t height, cl_float** weight);
 
-// generate weights from image
-void make_weight(const cl_float* image, size_t width, size_t height, double gain, double offset, cl_float** weight);
+// generate weights from image, gain and offset
+void make_weight(const cl_float* image, const double* gain, double offset, size_t width, size_t height, cl_float** weight);
 
 // read mask from file
 void read_mask(const char* filename, size_t width, size_t height, int** mask);

--- a/src/input.h
+++ b/src/input.h
@@ -14,8 +14,11 @@ typedef struct
     char* weight;
     char* mask;
     char* psf;
-    double gain;
     double offset;
+    struct gain {
+        char* file;
+        double value;
+    }* gain;
     
     // MultiNest
     int nlive;

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -172,11 +172,27 @@ int main(int argc, char* argv[])
     
     verbose("  image pixels: %zu", lensed.size);
     
-    // read weights if given, else generate from image
+    // check if weight map is given
     if(inp->opts->weight)
+    {
+        // read weight map from file as it is
         read_weight(inp->opts->weight, lensed.width, lensed.height, &lensed.weight);
+    }
     else
-        make_weight(lensed.image, lensed.width, lensed.height, inp->opts->gain, inp->opts->offset, &lensed.weight);
+    {
+        double* gain;
+        
+        // read gain if given, else make uniform gain map
+        if(inp->opts->gain->file)
+            read_gain(inp->opts->gain->file, lensed.width, lensed.height, &gain);
+        else
+            make_gain(inp->opts->gain->value, lensed.width, lensed.height, &gain);
+        
+        // make weight map from image, gain and offset
+        make_weight(lensed.image, gain, inp->opts->offset, lensed.width, lensed.height, &lensed.weight);
+        
+        free(gain);
+    }
     
     // start without masked pixels
     masked = 0;


### PR DESCRIPTION
cc @rbmetcalf @fabiobg83 

This should give us the right statistics when working with drizzled images. Here "gain" refers to the effective gain to go from counts/sec to absolute counts.

The variance in counts/sec is calculated from image, gain and offset as

```
variance[i] = (image[i] + offset)/gain[i]
```

Please someone check that this makes sense, I cannot find a good source on the statistics to use for these images.
