### PR TITLE
Fix ambiguous `mad24` overload in kernel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,6 @@ endif
 
 BUILD_DIR = build
 SOURCE_DIR = src
-TOOLS_DIR = tools
 BIN_DIR = bin
 CONFIG = $(BUILD_DIR)/config.h
 VERSION = $(SOURCE_DIR)/version.h

--- a/kernel/lensed.cl
+++ b/kernel/lensed.cl
@@ -66,8 +66,8 @@ kernel void convolve(global float* input, constant float* psf,
     int cw = PSF_WIDTH/2 + lw + PSF_WIDTH/2;
     int ch = PSF_HEIGHT/2 + lh + PSF_HEIGHT/2;
     int cs = cw*ch;
-    int cx = mad24(get_group_id(0), lw, - PSF_WIDTH/2);
-    int cy = mad24(get_group_id(1), lh, - PSF_HEIGHT/2);
+    int cx = mad24((int)get_group_id(0), lw, -PSF_WIDTH/2);
+    int cy = mad24((int)get_group_id(1), lh, -PSF_HEIGHT/2);
     
     // fill cache
     for(i = mad24(lj, lw, li); i < cs; i += ls)


### PR DESCRIPTION
This should fix the ambiguous overload from #98.

@rbmetcalf Could you checkout this PR (`git fetch && git checkout nt/fixes`) and see if that resolves the issue?
