### PR TITLE
Functions for and output of prior bounds.

### DIFF
--- a/src/prior.c
+++ b/src/prior.c
@@ -11,6 +11,8 @@ typedef void* (*read_func)(size_t, const char*[]);
 typedef void (*free_func)(void*);
 typedef double (*prior_func)(const void*, double);
 typedef void (*print_func)(const void*, char*, size_t);
+typedef double (*lower_func)(const void*);
+typedef double (*upper_func)(const void*);
 
 // item of prior list
 typedef struct
@@ -20,10 +22,12 @@ typedef struct
     free_func free;
     print_func print;
     prior_func prior;
+    lower_func lower;
+    upper_func upper;
 } prior_list;
 
 // macro to simplify definition of prior list
-#define PRIOR(x) { #x, read_prior_##x, free_prior_##x, print_prior_##x, prior_##x }
+#define PRIOR(x) { #x, read_prior_##x, free_prior_##x, print_prior_##x, prior_##x, prior_lower_##x, prior_upper_##x }
 
 // include all prior headers here
 #include "prior/delta.h"
@@ -43,6 +47,8 @@ struct prior
 {
     prior_func prior;
     print_func print;
+    lower_func lower;
+    upper_func upper;
     free_func free;
     void* data;
 };
@@ -124,6 +130,8 @@ prior* read_prior(const char* str)
     // set up prior functions
     pri->prior = PRIORS[pos].prior;
     pri->print = PRIORS[pos].print;
+    pri->lower = PRIORS[pos].lower;
+    pri->upper = PRIORS[pos].upper;
     pri->free = PRIORS[pos].free;
     
     // try to parse prior data
@@ -157,4 +165,14 @@ void print_prior(const prior* pri, char* buf, size_t n)
 void apply_prior(const prior* pri, double* u)
 {
     *u = pri->prior(pri->data, *u);
+}
+
+double prior_lower(const prior* pri)
+{
+    return pri->lower(pri->data);
+}
+
+double prior_upper(const prior* pri)
+{
+    return pri->upper(pri->data);
 }

--- a/src/prior.h
+++ b/src/prior.h
@@ -11,3 +11,9 @@ void print_prior(const prior* pri, char* buf, size_t n);
 
 // apply prior to unit variate
 void apply_prior(const prior* pri, double* u);
+
+// get lower bound for prior
+double prior_lower(const prior* pri);
+
+// get upper bound for prior
+double prior_upper(const prior* pri);

--- a/src/prior/delta.c
+++ b/src/prior/delta.c
@@ -38,3 +38,15 @@ double prior_delta(const void* data, double u)
 {
     return *(double*)data;
 }
+
+
+double prior_lower_delta(const void* data)
+{
+    return *(double*)data;
+}
+
+
+double prior_upper_delta(const void* data)
+{
+    return *(double*)data;
+}

--- a/src/prior/delta.h
+++ b/src/prior/delta.h
@@ -4,3 +4,5 @@ void* read_prior_delta(size_t nargs, const char* args[]);
 void free_prior_delta(void* data);
 void print_prior_delta(const void* data, char* buf, size_t n);
 double prior_delta(const void* data, double u);
+double prior_lower_delta(const void* data);
+double prior_upper_delta(const void* data);

--- a/src/prior/unif.c
+++ b/src/prior/unif.c
@@ -71,3 +71,17 @@ double prior_unif(const void* data, double u)
     
     return unif->a + u*(unif->b - unif->a);
 }
+
+double prior_lower_unif(const void* data)
+{
+    const struct uniform* unif = data;
+    
+    return unif->a;
+}
+
+double prior_upper_unif(const void* data)
+{
+    const struct uniform* unif = data;
+    
+    return unif->b;
+}

--- a/src/prior/unif.h
+++ b/src/prior/unif.h
@@ -4,3 +4,5 @@ void* read_prior_unif(size_t nargs, const char* args[]);
 void free_prior_unif(void* data);
 void print_prior_unif(const void* data, char* buf, size_t n);
 double prior_unif(const void* data, double u);
+double prior_lower_unif(const void* data);
+double prior_upper_unif(const void* data);


### PR DESCRIPTION
This PR implements prior bounds. Priors must provide two functions `prior_lower_xyz` and `prior_upper_xyz` that report their upper and lower bounds, respectively.
This information can be queried from a parameter using the `prior_lower` and `prior_upper` functions.
