### PR TITLE
Split `efr` option into separate `acc` and `shf` options.

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -25,8 +25,9 @@ typedef struct
     int ins;
     int mmodal;
     int ceff;
+    double acc;
     double tol;
-    double eff;
+    double shf;
     int maxmodes;
     int updint;
     int seed;

--- a/src/input/options.c
+++ b/src/input/options.c
@@ -140,16 +140,22 @@ struct option OPTIONS[] = {
         OPTION_FIELD(ceff)
     },
     {
+        "acc",
+        "Target acceptance rate",
+        OPTION_OPTIONAL(real, 0.05),
+        OPTION_FIELD(acc)
+    },
+    {
         "tol",
-        "Tolerance for evidence",
+        "Tolerance in log-evidence",
         OPTION_OPTIONAL(real, 0.1),
         OPTION_FIELD(tol)
     },
     {
-        "eff",
-        "Sampling efficiency",
-        OPTION_OPTIONAL(real, 0.05),
-        OPTION_FIELD(eff)
+        "shf",
+        "Shrinking factor",
+        OPTION_OPTIONAL(real, 0.8),
+        OPTION_FIELD(shf)
     },
     {
         "maxmodes",

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -658,6 +658,9 @@ int main(int argc, char* argv[])
         double logzero = -DBL_MAX;
         int* wrap;
         
+        // efficiency rating can mean different things, depending on ceff
+        double efr = inp->opts->ceff ? inp->opts->acc : inp->opts->shf;
+        
         // copy root element for file output if given
         if(inp->opts->root)
             strncpy(root, inp->opts->root, 99);
@@ -674,11 +677,10 @@ int main(int argc, char* argv[])
         
         // run MultiNest
         run(inp->opts->ins, inp->opts->mmodal, inp->opts->ceff,
-            inp->opts->nlive, inp->opts->tol, inp->opts->eff,
-            ndim, npar, nclspar, inp->opts->maxmodes, inp->opts->updint,
-            ztol, root, inp->opts->seed, wrap, fb, inp->opts->resume,
-            inp->opts->output, initmpi, logzero, inp->opts->maxiter,
-            loglike, dumper, &lensed);
+            inp->opts->nlive, inp->opts->tol, efr, ndim, npar, nclspar,
+            inp->opts->maxmodes, inp->opts->updint, ztol, root, inp->opts->seed,
+            wrap, fb, inp->opts->resume, inp->opts->output, initmpi, logzero,
+            inp->opts->maxiter, loglike, dumper, &lensed);
         
         // restore standard output
         logfile(NULL);


### PR DESCRIPTION
This PR takes the `efr` efficiency option and replaces it with `acc` target acceptance rate and `shf` shrinking factor.

The problem with MultiNest's `efr` is that it means two different things:
-   in constant efficiency mode, it's the target acceptance rate, and
-   in normal mode, it's the inverse of  the enlargement factor of the proposal ellipses.

This means that a default value such as `efr = 0.05` will only be reasonable in one of the two contexts above, and has to be kept in mind when experimenting with `ceff` on and off.

With the PR, there are explicit values for each of the meanings.
