### PR TITLE
Fix incorrect allocation of PSF buffer

### DIFF
--- a/src/lensed.c
+++ b/src/lensed.c
@@ -484,7 +484,7 @@ int main(int argc, char* argv[])
         image_mem = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR | CL_MEM_HOST_NO_ACCESS, lensed.size*sizeof(cl_float), lensed.image, NULL);
         weight_mem = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR | CL_MEM_HOST_NO_ACCESS, lensed.size*sizeof(cl_float), lensed.weight, NULL);
         if(psf)
-            psf_mem = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR | CL_MEM_HOST_NO_ACCESS, lensed.size*sizeof(cl_float), psf, &err);
+            psf_mem = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR | CL_MEM_HOST_NO_ACCESS, psfw*psfh*sizeof(cl_float), psf, &err);
         if(!image_mem || !weight_mem || err)
             error("failed to allocate data buffers");
     }


### PR DESCRIPTION
This PR corrects the allocation of the PSF buffer. Before, the allocated buffer was big enough to hold the observed image, leading to the bug reported in #110.

@rbmetcalf Could you test this and let me know if it fixes the problems?

Also includes a better error message which kernel failed.
