### PR TITLE
Fix line-too-long error if there's no final newline in ini

### DIFF
--- a/src/input/ini.c
+++ b/src/input/ini.c
@@ -152,7 +152,7 @@ void read_ini(const char* ini, input* inp)
         len = strcspn(buf, EOL);
         
         // make sure a whole line was read (i.e. line ends with EOL character)
-        if(buf[len] == '\0')
+        if(buf[len] == '\0' && !feof(file))
             errorf(ini, line, "line too long (max. %zu characters)", sizeof(buf));
         
         // terminate string at EOL


### PR DESCRIPTION
This PR fixes the error that ini file like

``` ini
...
last = this # no newline here
```

would lead to

```
error: line too long (max. 1024 characters)
```

because the last line was read without a terminating `\n`.
