### PR TITLE
Optimised and unified object code

### DIFF
--- a/kernel/constants.cl
+++ b/kernel/constants.cl
@@ -1,3 +1,7 @@
+//-----------
+// constants
+//-----------
+
 // trigonometry
 #define PI      3.1415926535897932384626433832795028841971693993751f
 #define PI_HALF 1.5707963267948966192313216916397514420985846996876f
@@ -8,5 +12,24 @@
 #define LOG_PI  1.1447298858494001741434273513530587116472948129153f
 #define LOG_2PI 1.8378770664093454835606594728112352797227949472756f
 
+
+//------------
 // image data
-#define IMAGE_CENTER ((float2)(0.5f*(IMAGE_WIDTH+1), 0.5f*(IMAGE_HEIGHT+1)))
+//------------
+
+// true center of the image
+#define IMAGE_CENTER ((float2)(0.5f*(IMAGE_WIDTH + 1), 0.5f*(IMAGE_HEIGHT + 1)))
+
+
+//----------
+// matrices
+//----------
+
+// 2x2 matrix type
+typedef float4 mat22;
+
+// 2x2 matrix vector multiplication
+inline static float2 mv22(mat22 m, float2 v)
+{
+    return (float2)(dot(m.lo, v), dot(m.hi, v));
+}

--- a/kernel/devauc.cl
+++ b/kernel/devauc.cl
@@ -16,35 +16,32 @@ PARAMS(devauc) = {
 
 struct devauc
 {
-    float2 x;
-    float4 t;
-    float rs;
-    float norm;
+    float2 x;   // source position
+    mat22 t;    // coordinate transformation matric
+    float rs;   // scale length
+    float norm; // normalisation
 };
 
-static float devauc(constant struct devauc* src, float2 x)
+static float devauc(constant struct devauc* data, float2 x)
 {
-    float4 t = src->t;
-    float2 y = x - src->x;
-    
-    y = (float2)(dot(t.lo, y), dot(t.hi, y));
-
-    float d = sqrt(dot(y, y));
-	
-    return src->norm*exp(-DEVAUC_B*pow(d/src->rs,0.25f));
+    // DeVaucouleur's profile for centered and rotated coordinate system
+    return data->norm*exp(-DEVAUC_B*sqrt(sqrt(length(mv22(data->t, x - data->x))/data->rs)));
 }
 
-static void set_devauc(global struct devauc* src, float x1, float x2, float r, float mag, float q, float pa)
+static void set_devauc(global struct devauc* data, float x1, float x2, float r, float mag, float q, float pa)
 {
     float c = cos(pa*DEG2RAD);
     float s = sin(pa*DEG2RAD);
     
     // source position
-    src->x = (float2)(x1, x2);
+    data->x = (float2)(x1, x2);
     
     // transformation matrix: rotate and scale
-    src->t = (float4)(q*c, q*s, -s, c);
+    data->t = (mat22)(q*c, q*s, -s, c);
     
-    src->rs = r;
-    src->norm = exp(-0.4f*mag*LOG_10)/PI/r/r/q*DEVAUC_C;
+    // scale length
+    data->rs = r;
+    
+    // normalisation to total luminosity
+    data->norm = exp(-0.4f*mag*LOG_10)/PI/r/r/q*DEVAUC_C;
 }

--- a/kernel/exponential.cl
+++ b/kernel/exponential.cl
@@ -11,35 +11,32 @@ PARAMS(exponential) = {
 
 struct exponential
 {
-    float2 x;
-    float4 t;
-    float rs;
-    float norm;
+    float2 x;   // source position
+    mat22 t;    // coordinate transformation matrix
+    float rs;   // scale length
+    float norm; // normalisation
 };
 
-static float exponential(constant struct exponential* src, float2 x)
+static float exponential(constant struct exponential* data, float2 x)
 {
-    float4 t = src->t;
-    float2 y = x - src->x;
-    
-    y = (float2)(dot(t.lo, y), dot(t.hi, y));
-
-    float d = sqrt(dot(y, y));
-	
-    return src->norm*exp(-d/src->rs);
+    // exponential profile for centered and rotated coordinate system
+    return data->norm*exp(-length(mv22(data->t, x - data->x))/data->rs);
 }
 
-static void set_exponential(global struct exponential* src, float x1, float x2, float rs, float mag, float q, float pa)
+static void set_exponential(global struct exponential* data, float x1, float x2, float rs, float mag, float q, float pa)
 {
     float c = cos(pa*DEG2RAD);
     float s = sin(pa*DEG2RAD);
     
     // source position
-    src->x = (float2)(x1, x2);
+    data->x = (float2)(x1, x2);
     
     // transformation matrix: rotate and scale
-    src->t = (float4)(q*c, q*s, -s, c);
+    data->t = (mat22)(q*c, q*s, -s, c);
     
-    src->rs = rs;
-    src->norm = exp(-0.4f*mag*LOG_10)*0.5f/PI/rs/rs/q;
+    // scale length
+    data->rs = rs;
+    
+    // normalisation to total luminosity
+    data->norm = exp(-0.4f*mag*LOG_10)*0.5f/PI/rs/rs/q;
 }

--- a/kernel/nsis.cl
+++ b/kernel/nsis.cl
@@ -1,4 +1,5 @@
 // non-singular isothermal sphere
+// follows Schneider, Kochanek, Wambsganss (2006)
 
 OBJECT(nsis) = LENS;
 
@@ -6,36 +7,33 @@ PARAMS(nsis) = {
     { "x" },
     { "y" },
     { "r" },
-    { "rc" },
+    { "rc" }
 };
 
 struct nsis
 {
-    float2 x;
-    float d;
-    float rc;
+    float2 x; // lens position
+    float r;  // Einstein radius
+    float rc; // core radius
 };
 
-static float2 nsis(constant struct nsis* nsis, float2 x)
+static float2 nsis(constant struct nsis* data, float2 x)
 {
-    float2 y;
-    float r;
+    // move to central coordinates
+    x -= data->x;
     
-    y = x - nsis->x;
-
-    r = 1./(nsis->rc+sqrt(y.x*y.x + y.y*y.y));
-
-    y = nsis->d*(float2)(y.x*r, y.y*r);
-    
-    return y;
+    // NSIS deflection
+    return data->r/(data->rc + length(x))*x;
 }
 
 static void set_nsis(global struct nsis* nsis, float x1, float x2, float r, float rc)
 {
     // lens position
     nsis->x = (float2)(x1, x2);
+    
     // Einstein radius
-    nsis->d = r;
+    nsis->r = r;
+    
     // core radius
     nsis->rc = rc;
 }

--- a/kernel/point_mass.cl
+++ b/kernel/point_mass.cl
@@ -1,37 +1,30 @@
-// A point mass lens
+// point mass lens
 
 OBJECT(point_mass) = LENS;
 
 PARAMS(point_mass) = {
     { "x" },
     { "y" },
-    { "re" }  // Einstein radius in pixels 
+    { "r" }
 };
 
 struct point_mass
 {
-    float2 x;
-    float re2;
+    float2 x; // lens position
+    float r2; // Einstein radius squared
 };
 
-static float2 point_mass(constant struct point_mass* point_mass, float2 x)
+static float2 point_mass(constant struct point_mass* data, float2 x)
 {
-    float2 y;
-    float r;
-    
-    y = x - point_mass->x;
-
-    r = 1./(y.x*y.x + y.y*y.y);
-
-    y = point_mass->re2*r*(float2)(y.x, y.y);
-    
-    return y;
+    // point mass deflection
+    return data->r2*normalize(x - data->x);
 }
 
-static void set_point_mass(global struct point_mass* point_mass, float x1, float x2, float re)
+static void set_point_mass(global struct point_mass* data, float x1, float x2, float r)
 {
     // lens position
-    point_mass->x = (float2)(x1, x2);
-    // Einstein radius
-    point_mass->re2 = re*re;
+    data->x = (float2)(x1, x2);
+    
+    // Einstein radius squared
+    data->r2 = r*r;
 }

--- a/kernel/sersic.cl
+++ b/kernel/sersic.cl
@@ -12,24 +12,20 @@ PARAMS(sersic) = {
 
 struct sersic
 {
-    float2 x;
-    float4 t;
-    float log0;
+    float2 x;   // source position
+    mat22 t;    // coordinate transformation matrix
+    float log0; // profile constants
     float log1;
     float m;
 };
 
-static float sersic(constant struct sersic* src, float2 x)
+static float sersic(constant struct sersic* data, float2 x)
 {
-    float4 t = src->t;
-    float2 y = x - src->x;
-    
-    y = (float2)(dot(t.lo, y), dot(t.hi, y));
-    
-    return exp(src->log0 - exp(src->log1 + src->m*log(dot(y, y))));
+    float2 y = mv22(data->t, x - data->x);
+    return exp(data->log0 - exp(data->log1 + data->m*log(dot(y, y))));
 }
 
-static void set_sersic(global struct sersic* src, float x1, float x2, float r, float mag, float n, float q, float pa)
+static void set_sersic(global struct sersic* data, float x1, float x2, float r, float mag, float n, float q, float pa)
 {
     float b = 1.9992f*n - 0.3271f; // approximation valid for 0.5 < n < 8
     
@@ -37,12 +33,12 @@ static void set_sersic(global struct sersic* src, float x1, float x2, float r, f
     float s = sin(pa*DEG2RAD);
     
     // source position
-    src->x = (float2)(x1, x2);
+    data->x = (float2)(x1, x2);
     
     // transformation matrix: rotate and scale
-    src->t = (float4)(q*c, q*s, -s, c);
+    data->t = (mat22)(q*c, q*s, -s, c);
     
-    src->log0 = -0.4f*mag*LOG_10 + 2*n*log(b) - LOG_PI - 2*log(r) - log(tgamma(2*n+1));
-    src->log1 = log(b) - (0.5f*log(q) + log(r))/n;
-    src->m = 0.5f/n;
+    data->log0 = -0.4f*mag*LOG_10 + 2*n*log(b) - LOG_PI - 2*log(r) - log(tgamma(2*n+1));
+    data->log1 = log(b) - (0.5f*log(q) + log(r))/n;
+    data->m = 0.5f/n;
 }

--- a/kernel/sis.cl
+++ b/kernel/sis.cl
@@ -1,37 +1,31 @@
 // singular isothermal sphere
+// follows Schneider, Kochanek, Wambsganss (2006)
 
 OBJECT(sis) = LENS;
 
 PARAMS(sis) = {
     { "x" },
     { "y" },
-    { "r" },
+    { "r" }
 };
 
 struct sis
 {
-    float2 x;
-    float d;
+    float2 x; // lens position
+    float r;  // Einstein radius
 };
 
-static float2 sis(constant struct sis* sis, float2 x)
+static float2 sis(constant struct sis* data, float2 x)
 {
-    float2 y;
-    float r;
-    
-    y = x - sis->x;
-
-    r = 1./sqrt(y.x*y.x + y.y*y.y);
-
-    y = sis->d*(float2)(y.x*r, y.y*r);
-    
-    return y;
+    // SIS deflection
+    return data->r*normalize(x - data->x);
 }
 
-static void set_sis(global struct sis* sis, float x1, float x2, float r)
+static void set_sis(global struct sis* data, float x1, float x2, float r)
 {
     // lens position
-    sis->x = (float2)(x1, x2);
+    data->x = (float2)(x1, x2);
+    
     // Einstein radius
-    sis->d = r;
+    data->r = r;
 }

--- a/kernel/sis_plus_shear.cl
+++ b/kernel/sis_plus_shear.cl
@@ -12,37 +12,28 @@ PARAMS(sis_plus_shear) = {
 
 struct sis_plus_shear
 {
-    float2 x;
-    float g1;
-    float g2;
-    float d;
+    float2 x; // lens position
+    mat22 g;  // shear matrix
+    float r;  // Einstein radius
 };
 
-static float2 sis_plus_shear(constant struct sis_plus_shear* sis_plus_shear, float2 x)
+static float2 sis_plus_shear(constant struct sis_plus_shear* data, float2 x)
 {
-    float2 y,dx;
-    float r;
+    // move to central coordinates
+    x -= data->x;
     
-    dx = x - sis_plus_shear->x;
-
-    r = 1./sqrt(dx.x*dx.x + dx.y*dx.y);
-
-    y = sis_plus_shear->d*(float2)(dx.x*r, dx.y*r);
-    y = y + (float2)(sis_plus_shear->g1*dx.x + sis_plus_shear->g2*dx.y
-      	            ,sis_plus_shear->g2*dx.x - sis_plus_shear->g1*dx.y)  ; 
-    
-    
-    
-    return y;
+    // SIS deflection plus external shear
+    return data->r*normalize(x) + mv22(data->g, x);
 }
 
-static void set_sis_plus_shear(global struct sis_plus_shear* sis_plus_shear, float x1, float x2
-, float r, float g1, float g2)
+static void set_sis_plus_shear(global struct sis_plus_shear* data, float x1, float x2, float r, float g1, float g2)
 {
     // lens position
-    sis_plus_shear->x = (float2)(x1, x2);
+    data->x = (float2)(x1, x2);
+    
     // Einstein radius
-    sis_plus_shear->d = r;
-    sis_plus_shear->g1 = g1;
-    sis_plus_shear->g2 = g2;
+    data->r = r;
+    
+    // shear matrix
+    data->g = (mat22)(g1, g2, g2, -g1);
 }


### PR DESCRIPTION
This PR tries to make the existing object code as fast as possible.

I included an alias `mat22` for the existing `float4` type to make it clear that certain objects are used as 2x2 matrices. There is a `mv22` function as well that does 2x2 matrix vector multiplication.

To make everything more consistent, I have tried to do the same operations in the same way across all the existing objects. Most things are commented.
