### PR TITLE
Pixel coordinate system

### DIFF
--- a/kernel/lensed.cl
+++ b/kernel/lensed.cl
@@ -1,5 +1,5 @@
 // compute image
-kernel void render(constant char* data,
+kernel void render(constant char* data, float4 pcs,
                    constant float2* qq, constant float2* ww,
                    global float* value, global float* error)
 {
@@ -12,7 +12,7 @@ kernel void render(constant char* data,
     if(i < IMAGE_WIDTH && j < IMAGE_HEIGHT)
     {
         // pixel position
-        float2 x = (float2)(1 + i, 1 + j);
+        float2 x = pcs.xy + pcs.zw*(float2)(i, j);
         
         // value and error of quadrature
         float2 f = 0;

--- a/src/data.h
+++ b/src/data.h
@@ -1,7 +1,19 @@
 #pragma once
 
+// pixel coordinate system
+typedef struct
+{
+    long rx;    // x reference pixel
+    long ry;    // y reference pixel
+    double sx;  // x pixel scale
+    double sy;  // y pixel scale
+} pcsdata;
+
 // read image from file
 void read_image(const char* filename, size_t* width, size_t* height, cl_float** image);
+
+// read pixel coordinate system from image file
+void read_pcs(const char* filename, pcsdata* pcs);
 
 // read gain from file
 void read_gain(const char* filename, size_t width, size_t height, double** gain);

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -39,6 +39,7 @@ int main(int argc, char* argv[])
     struct lensed lensed;
     
     // data
+    pcsdata* pcs;
     size_t masked;
     cl_float* psf;
     size_t psfw;
@@ -172,6 +173,15 @@ int main(int argc, char* argv[])
     lensed.size = lensed.width*lensed.height;
     
     verbose("  image pixels: %zu", lensed.size);
+    
+    // read image pixel coordinate system
+    pcs = malloc(sizeof(pcsdata));
+    if(!pcs)
+        errori(NULL);
+    read_pcs(inp->opts->image, pcs);
+    
+    verbose("  pixel origin: ( %ld, %ld )", pcs->rx, pcs->ry);
+    verbose("  pixel scale: ( %f, %f )", pcs->sx, pcs->sy);
     
     // check if weight map is given
     if(inp->opts->weight)
@@ -333,7 +343,7 @@ int main(int argc, char* argv[])
         errori(NULL);
     
     // get quadrature rule
-    quad_rule(qq, ww);
+    quad_rule(qq, ww, pcs->sx, pcs->sy);
     
     
     /****************
@@ -541,12 +551,20 @@ int main(int argc, char* argv[])
     
     // create kernel
     {
+        cl_float4 pcs4;
+        
         verbose("  create render buffer");
         
         lensed.value_mem = clCreateBuffer(context, CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR | CL_MEM_HOST_READ_ONLY, lensed.size*sizeof(cl_float), NULL, NULL);
         lensed.error_mem = clCreateBuffer(context, CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR | CL_MEM_HOST_READ_ONLY, lensed.size*sizeof(cl_float), NULL, NULL);
         if(!lensed.value_mem || !lensed.error_mem)
             error("failed to create render buffer");
+        
+        // pixel coordinate system
+        pcs4.s[0] = pcs->rx;
+        pcs4.s[1] = pcs->ry;
+        pcs4.s[2] = pcs->sx;
+        pcs4.s[3] = pcs->sy;
         
         verbose("  create render kernel");
         
@@ -556,10 +574,11 @@ int main(int argc, char* argv[])
             error("failed to create render kernel");
         err = 0;
         err |= clSetKernelArg(lensed.render, 0, sizeof(cl_mem), &object_mem);
-        err |= clSetKernelArg(lensed.render, 1, sizeof(cl_mem), &qq_mem);
-        err |= clSetKernelArg(lensed.render, 2, sizeof(cl_mem), &ww_mem);
-        err |= clSetKernelArg(lensed.render, 3, sizeof(cl_mem), &lensed.value_mem);
-        err |= clSetKernelArg(lensed.render, 4, sizeof(cl_mem), &lensed.error_mem);
+        err |= clSetKernelArg(lensed.render, 1, sizeof(cl_float4), &pcs4);
+        err |= clSetKernelArg(lensed.render, 2, sizeof(cl_mem), &qq_mem);
+        err |= clSetKernelArg(lensed.render, 3, sizeof(cl_mem), &ww_mem);
+        err |= clSetKernelArg(lensed.render, 4, sizeof(cl_mem), &lensed.value_mem);
+        err |= clSetKernelArg(lensed.render, 5, sizeof(cl_mem), &lensed.error_mem);
         if(err != CL_SUCCESS)
             error("failed to set render kernel arguments");
         
@@ -833,6 +852,7 @@ int main(int argc, char* argv[])
     
     // free data
     free(lensed.image);
+    free(pcs);
     free(lensed.weight);
     free(psf);
     

--- a/src/quadrature.c
+++ b/src/quadrature.c
@@ -53,14 +53,14 @@ size_t quad_points()
     return QUAD_N*QUAD_N;
 }
 
-void quad_rule(cl_float2 xx[], cl_float2 ww[])
+void quad_rule(cl_float2 xx[], cl_float2 ww[], double sx, double sy)
 {
     for(size_t i = 0, j = 0; j < QUAD_N; ++j)
     {
         for(size_t k = 0; k < QUAD_N; ++k, ++i)
         {
-            xx[i].s[0] = QUAD_ABSC[k];
-            xx[i].s[1] = QUAD_ABSC[j];
+            xx[i].s[0] = sx*QUAD_ABSC[k];
+            xx[i].s[1] = sy*QUAD_ABSC[j];
             ww[i].s[0] = QUAD_WEIG[j]*QUAD_WEIG[k];
             ww[i].s[1] = QUAD_ERRW[j]*QUAD_ERRW[k];
         }

--- a/src/quadrature.h
+++ b/src/quadrature.h
@@ -4,4 +4,4 @@
 size_t quad_points();
 
 /* generate n quadrature rules */
-void quad_rule(cl_float2 xx[], cl_float2 ww[]);
+void quad_rule(cl_float2 xx[], cl_float2 ww[], double sx, double sy);


### PR DESCRIPTION
This PR introduces a true pixel coordinate system (PCS) into Lensed. This means both an origin different from (1, 1) for the bottom left pixel, and a scale different from (1, 1) for the pixel size.

The PCS is useful for two things. Firstly, we can now work on sections of a larger FITS file directly without pre-processing (cf. #14). For example, imagine you downloaded a drz FITS file, you can go to work right away using the extended filename syntax

``` ini
image  = hst_wfc3_uvis_f475w_drz.fits[SCI][2001:2350, 3201:3550]
gain   = hst_wfc3_uvis_f475w_drz.fits[EXP][2001:2350, 3201:3550]
```

for cutting the portion `[2001:2350, 3201:3550]` out of the `SCI` and `EXP` extensions of the FITS data cube. Using this syntax, the PCS is adjusted automatically to the new origin, so that the position prior

``` ini
host.x     = unif 2170 2180
host.y     = unif 3360 3370
```

corresponds exactly to what you would see in DS9 using the full image.

That's not all that can be done using the FITS extended filenames. For a quick test, you might decide to effectively reduce the resolution of the image by selecting every second row and column. This can be done with the filename extension `[2001:2350:2, 3201:3550:2]` natively. The PCS takes this into account and scales the pixel sizes accordingly, so that all resulting quantities are still correctly scaled for the full resolution image!

The second thing this is useful (and in fact necessary) for is to have sub-sampled PSFs in the future, where we will need to calculate the image at a higher resolution.
