### PR TITLE
Flag to list computation devices

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -36,6 +36,7 @@ void usage(int help)
         printf("  %-16s  %s\n", "-b, --batch", "Batch output.");
         printf("  %-16s  %s\n", "-q, --quiet", "Suppress all output.");
         printf("  %-16s  %s\n", "--version", "Show version number.");
+        printf("  %-16s  %s\n", "--devices", "List computation devices.");
         printf("  %-16s  %s\n", "--batch-header", "Batch output header.");
         for(size_t i = 0, n = noptions(); i < n; ++i)
         {
@@ -132,6 +133,8 @@ input* read_input(int argc, char* argv[])
                     log_level(LOG_QUIET);
                 else if(strcmp(argv[i]+2, "version") == 0)
                     version();
+                else if(strcmp(argv[i]+2, "devices") == 0)
+                    inp->opts->devices = 1;
                 else if(strcmp(argv[i]+2, "batch-header") == 0)
                     inp->opts->batch_header = 1;
                 else
@@ -175,7 +178,7 @@ input* read_input(int argc, char* argv[])
     }
     
     // check input if not in a special mode
-    if(!(inp->opts->batch_header))
+    if(!(inp->opts->devices || inp->opts->batch_header))
     {
         // make sure all required options are resolved
         for(size_t i = 0, n = noptions(); i < n; ++i)

--- a/src/input.h
+++ b/src/input.h
@@ -7,6 +7,7 @@ typedef struct
     int gpu;
     int output;
     char* root;
+    int devices;
     int batch_header;
     
     // data


### PR DESCRIPTION
This PR adds a `--devices` flag to make Lensed print a list of available OpenCL devices.

Sample output:

```
$ lensed --devices
device: Intel(R) Core(TM) i7-3520M CPU @ 2.90GHz
  type: CPU
  vendor: Intel
  version: OpenCL 1.2 
  compiler: OpenCL C 1.2 
  driver: 1.1
  units: 4
device: HD Graphics 4000
  type: GPU
  vendor: Intel
  version: OpenCL 1.2 
  compiler: OpenCL C 1.2 
  driver: 1.2(Dec 23 2014 00:18:31)
  units: 16
```
