### PR TITLE
Fix blank log files

### DIFF
--- a/src/lensed.c
+++ b/src/lensed.c
@@ -71,7 +71,8 @@ int main(int argc, char* argv[])
     cl_mem psf_mem;
     
     // log file for capturing library output
-    char* logfil;
+    char* lognam;
+    FILE* logfil;
     
     // timer for duration
     time_t start, end;
@@ -765,18 +766,23 @@ int main(int argc, char* argv[])
     // name of log file
     if(inp->opts->output)
     {
-        logfil = malloc(strlen(inp->opts->root) + strlen("log.txt") + 1);
-        if(!logfil)
+        lognam = malloc(strlen(inp->opts->root) + strlen("log.txt") + 1);
+        if(!lognam)
             errori(NULL);
-        sprintf(logfil, "%slog.txt", inp->opts->root);
+        sprintf(lognam, "%slog.txt", inp->opts->root);
     }
     else
     {
-        logfil = malloc(sizeof(NUL_DEV));
-        if(!logfil)
+        lognam = malloc(sizeof(NUL_DEV));
+        if(!lognam)
             errori(NULL);
-        strcpy(logfil, NUL_DEV);
+        strcpy(lognam, NUL_DEV);
     }
+    
+    // open log file
+    logfil = fopen(lognam, "w");
+    if(!logfil)
+        errorf(lognam, 0, "could not write log file");
     
     // take start time
     start = time(0);
@@ -979,7 +985,7 @@ int main(int argc, char* argv[])
     // there might be output left in Fortran's buffer, so redirect again
     // to log file, which is not closed on purpose
     logfile(logfil);
-    free(logfil);
+    free(lognam);
     
     return EXIT_SUCCESS;
 }

--- a/src/log.c
+++ b/src/log.c
@@ -1,5 +1,4 @@
 #include <stdlib.h>
-#include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>
@@ -163,18 +162,11 @@ void errorfi(const char* file, size_t line, const char* msg, ...)
     exit(EXIT_FAILURE);
 }
 
-void logfile(const char* logfile)
+void logfile(FILE* f)
 {
-    // redirect if logfile is given, else restore stdout
-    if(logfile)
+    // redirect if file is given, else restore stdout
+    if(f)
     {
-        FILE* f;
-        
-        // open logfile
-        f = fopen(logfile, "w");
-        if(!f)
-            errorf(logfile, 0, "could not write logfile", logfile);
-        
         // flush standard output
         fflush(stdout);
         
@@ -185,9 +177,6 @@ void logfile(const char* logfile)
         
         // redirect standard output to logfile
         dup2(fileno(f), STDOUT_FILENO);
-        
-        // a copy of logfile lives in stdout
-        fclose(f);
     }
     else
     {

--- a/src/log.h
+++ b/src/log.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdio.h>
+
 // the individual levels of logging
 extern enum log_level
 {
@@ -36,7 +38,7 @@ void errori(const char* msg, ...);
 void errorfi(const char* file, size_t line, const char* msg, ...);
 
 // redirect standard output to logfile, restore stdout when NULL is passed
-void logfile(const char* logfile);
+void logfile(FILE* f);
 
 // some output codes for Unix-like terminals
 #define LOG_BOLD "\033[1m"


### PR DESCRIPTION
This PR fixes the issue with log files being empty. The problem was that files would be reopened at the end of the program to flush any leftover output from MultiNest, truncating any existing input.
