### PR TITLE
Individual work sizes for kernels

### DIFF
--- a/kernel/lensed.cl
+++ b/kernel/lensed.cl
@@ -3,16 +3,14 @@ kernel void render(constant char* data, float4 pcs,
                    constant float2* qq, constant float2* ww,
                    global float* value, global float* error)
 {
-    // get pixel indices
-    int i = get_global_id(0);
-    int j = get_global_id(1);
-    int k = mad24(j, IMAGE_WIDTH, i);
+    // get pixel index
+    int k = get_global_id(0);
     
     // compute pixel flux if pixel is in image
-    if(i < IMAGE_WIDTH && j < IMAGE_HEIGHT)
+    if(k < IMAGE_SIZE)
     {
         // pixel position
-        float2 x = pcs.xy + pcs.zw*(float2)(i, j);
+        float2 x = pcs.xy + pcs.zw*(float2)(k%IMAGE_WIDTH, k/IMAGE_WIDTH);
         
         // value and error of quadrature
         float2 f = 0;
@@ -32,12 +30,10 @@ kernel void loglike(global const float* image, global const float* weight,
                     global const float* model, global float* loglike)
 {
     // get pixel index
-    int i = get_global_id(0);
-    int j = get_global_id(1);
-    int k = mad24(j, IMAGE_WIDTH, i);
+    int k = get_global_id(0);
     
     // compute chi^2 value if pixel is in image
-    if(i < IMAGE_WIDTH && j < IMAGE_HEIGHT)
+    if(k < IMAGE_SIZE)
     {
         float d = model[k] - image[k];
         loglike[k] = weight[k]*d*d;

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -575,6 +575,7 @@ const char* kernel_options(size_t width, size_t height, int psf, size_t psfw, si
     const char** f;
     
     // hard-coded options
+    const char* size_opt = " -DIMAGE_SIZE=%zu";
     const char* width_opt = " -DIMAGE_WIDTH=%zu";
     const char* height_opt = " -DIMAGE_HEIGHT=%zu";
     const char* psf_opt = " -DPSF=%d";
@@ -585,6 +586,8 @@ const char* kernel_options(size_t width, size_t height, int psf, size_t psfw, si
     // get number of options and their sizes
     opts_size = 0;
     nopts = 0;
+    opts_size += strlen(size_opt) + log10(width*height + 1) + 1;
+    nopts += 1;
     opts_size += strlen(width_opt) + log10(width + 1) + 1;
     nopts += 1;
     opts_size += strlen(height_opt) + log10(height + 1) + 1;
@@ -612,6 +615,7 @@ const char* kernel_options(size_t width, size_t height, int psf, size_t psfw, si
     cur = opts;
     
     // write hard-coded options
+    cur += sprintf(cur, size_opt, width*height);
     cur += sprintf(cur, width_opt, width);
     cur += sprintf(cur, height_opt, height);
     cur += sprintf(cur, psf_opt, psf ? 1 : 0);

--- a/src/lensed.h
+++ b/src/lensed.h
@@ -28,20 +28,26 @@ struct lensed
     // worker queue
     cl_command_queue queue;
     
-    // global and local work size
-    size_t lws[2];
-    size_t gws[2];
-    
     // parameter kernel
     cl_kernel set_params;
     cl_mem params;
     
-    // kernel
-    cl_kernel render;
+    // render kernel
     cl_mem value_mem;
     cl_mem error_mem;
-    cl_kernel convolve;
+    cl_kernel render;
+    size_t render_lws[1];
+    size_t render_gws[1];
+    
+    // convolve kernel
     cl_mem convolve_mem;
-    cl_kernel loglike;
+    cl_kernel convolve;
+    size_t convolve_lws[2];
+    size_t convolve_gws[2];
+    
+    // loglike kernel
     cl_mem loglike_mem;
+    cl_kernel loglike;
+    size_t loglike_lws[1];
+    size_t loglike_gws[1];
 };

--- a/src/nested.c
+++ b/src/nested.c
@@ -47,20 +47,20 @@ void loglike(double cube[], int* ndim, int* npar, double* lnew, void* lensed_)
         error("failed to set parameters");
     
     // simulate objects
-    err = clEnqueueNDRangeKernel(lensed->queue, lensed->render, 2, NULL, lensed->gws, lensed->lws, 0, NULL, NULL);
+    err = clEnqueueNDRangeKernel(lensed->queue, lensed->render, 1, NULL, lensed->render_gws, lensed->render_lws, 0, NULL, NULL);
     if(err != CL_SUCCESS)
         error("failed to run render kernel");
     
     // convolve with PSF if given
     if(lensed->convolve)
     {
-        err = clEnqueueNDRangeKernel(lensed->queue, lensed->convolve, 2, NULL, lensed->gws, lensed->lws, 0, NULL, NULL);
+        err = clEnqueueNDRangeKernel(lensed->queue, lensed->convolve, 2, NULL, lensed->convolve_gws, lensed->convolve_lws, 0, NULL, NULL);
         if(err != CL_SUCCESS)
             error("failed to run convolve kernel");
     }
     
     // compare with observed image
-    err = clEnqueueNDRangeKernel(lensed->queue, lensed->loglike, 2, NULL, lensed->gws, lensed->lws, 0, NULL, NULL);
+    err = clEnqueueNDRangeKernel(lensed->queue, lensed->loglike, 1, NULL, lensed->loglike_gws, lensed->loglike_lws, 0, NULL, NULL);
     if(err != CL_SUCCESS)
         error("failed to run loglike kernel");
     
@@ -137,14 +137,14 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
             error("failed to set parameters");
         
         // simulate objects
-        err = clEnqueueNDRangeKernel(lensed->queue, lensed->render, 2, NULL, lensed->gws, lensed->lws, 0, NULL, NULL);
+        err = clEnqueueNDRangeKernel(lensed->queue, lensed->render, 1, NULL, lensed->render_gws, lensed->render_lws, 0, NULL, NULL);
         if(err != CL_SUCCESS)
             error("failed to run render kernel");
         
         // convolve with PSF if given
         if(lensed->convolve)
         {
-            err = clEnqueueNDRangeKernel(lensed->queue, lensed->convolve, 2, NULL, lensed->gws, lensed->lws, 0, NULL, NULL);
+            err = clEnqueueNDRangeKernel(lensed->queue, lensed->convolve, 2, NULL, lensed->convolve_gws, lensed->convolve_lws, 0, NULL, NULL);
             if(err != CL_SUCCESS)
                 error("failed to run convolve kernel");
         }


### PR DESCRIPTION
This PR introduces individual work sizes for the OpenCL kernels as mentioned in #85. The `render` and `loglike` kernels work once again in one dimension, which simplifies things. Only the `convolve` kernel is two-dimensional.

Work sizes are based on the maximum size allowed for each kernel and dimension. They respect the preferred multiple that OpenCL reports.

In addition to this, I have tried to make the block size for the convolution adapt to the limitations imposed by the available local memory. This is very rough, and I'm sure it's possible to improve this a lot.
