### PR TITLE
fix FWHM estimation of background counts

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -294,7 +294,7 @@ void find_mode(size_t nvalues, const cl_float values[], const cl_float mask[], d
 {
     double min, max, dx;
     size_t* counts;
-    size_t i, j;
+    long i, j;
     
     // make sure there are values
     if(nvalues == 0)


### PR DESCRIPTION
There was a bug similar to glenco/SLsimLib#5 where a `size_t` would wraparound in subtraction and create huge values.
