### PR TITLE
support for default config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,6 @@ SOURCES = lensed.c \
 
 
 ####
-# config
-####
-
-KERNEL_PATH = $(shell pwd)/kernel
-KERNEL_EXT = .cl
-
-
-####
 # compiler and linker settings
 ####
 
@@ -90,6 +82,13 @@ endif
 
 
 ####
+# config
+####
+
+LENSED_PATH = $(dir $(CURDIR)/$(word $(words $(MAKEFILE_LIST)), $(MAKEFILE_LIST)))
+
+
+####
 # build rules
 ####
 
@@ -115,8 +114,7 @@ $(CONFIG): Makefile
 	@$(MKDIR) $(@D)
 	@$(ECHO) "#pragma once" >> $@
 	@$(ECHO) "" >> $@
-	@$(ECHO) "#define KERNEL_PATH \"$(KERNEL_PATH)/\"" >> $@
-	@$(ECHO) "#define KERNEL_EXT \"$(KERNEL_EXT)\"" >> $@
+	@$(ECHO) "#define LENSED_PATH \"$(LENSED_PATH)\"" >> $@
 
 $(OBJECTS): $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.c $(CONFIG) $(VERSION)
 	@$(ECHO) "building $(STYLE_BOLD)$<$(STYLE_RESET)"

--- a/src/input.c
+++ b/src/input.c
@@ -8,9 +8,13 @@
 #include "input/ini.h"
 #include "prior.h"
 #include "log.h"
+#include "config.h"
 #include "version.h"
 
-/* print usage help */
+// default config file
+const char DEFAULT_INI[] = "default.ini";
+
+// print usage help
 void usage(int help)
 {
     if(help)
@@ -109,7 +113,29 @@ input* read_input(int argc, char* argv[])
     // set default options
     default_options(inp);
     
-    /* go through arguments */
+    // check for a default config file
+    {
+        char* filename;
+        FILE* fp;
+        
+        // get filename of default config file
+        filename = malloc(strlen(LENSED_PATH) + strlen(DEFAULT_INI) + 1);
+        if(!filename)
+            errori(NULL);
+        sprintf(filename, "%s%s", LENSED_PATH, DEFAULT_INI);
+        
+        // check if default config file exists
+        fp = fopen(filename, "r");
+        fclose(fp);
+        
+        // if file exists, read it
+        if(fp)
+            read_ini(filename, inp);
+        
+        free(filename);
+    }
+    
+    // go through arguments
     for(int i = 1; i < argc; ++i)
     {
         // check for option

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -8,6 +8,10 @@
 #include "kernel.h"
 #include "log.h"
 
+// parts of kernel files
+static const char KERNEL_DIR[] = "kernel/";
+static const char KERNEL_EXT[] = ".cl";
+
 // marker for individual files in kernel code
 static const char FILEHEAD[] = 
     "//----------------------------------------------------------------------------\n"
@@ -452,8 +456,8 @@ static const char* load_kernel(const char* name)
     int wri;
     
     // construct filename for kernel
-    filename = malloc(strlen(KERNEL_PATH) + strlen(name) + strlen(KERNEL_EXT) + 1);
-    sprintf(filename, "%s%s%s", KERNEL_PATH, name, KERNEL_EXT);
+    filename = malloc(strlen(LENSED_PATH) + strlen(KERNEL_DIR) + strlen(name) + strlen(KERNEL_EXT) + 1);
+    sprintf(filename, "%s%s%s%s", LENSED_PATH, KERNEL_DIR, name, KERNEL_EXT);
     
     // try to read file
     f = fopen(filename, "r");


### PR DESCRIPTION
With this PR, it is possible to put a file called "default.ini" into the top-level directory of Lensed and have it included automatically whenever Lensed is run.

This file can be useful to override the intrinsic default options, e.g. to fix the default `device` option to something else than `gpu0`.
