### PR TITLE
added OpenCL to list of requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-lensed
+Lensed
 ======
 
 Reconstruct gravitational lenses and lensed sources from strong lensing observations.
@@ -11,6 +11,7 @@ Installation
 
 Lensed needs the following libraries in order to compile:
 
+-   OpenCL 1.2
 -   [CFITSIO] 3.370
 -   [MultiNest] 3.9
 


### PR DESCRIPTION
The readme file should mention that an implementation of OpenCL 1.2 is required to build Lensed.
