### PR TITLE
fix infinite deflections

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -82,8 +82,8 @@ static const char COMPLENS[] =
 ;
 static const char COMPDEFL[] =
     "    \n"
-    "    // apply deflection to ray\n"
-    "    y -= a;\n"
+    "    // apply deflection to ray, if finite\n"
+    "    y -= dot(a,a) < HUGE_VALF ? a : (float2)(1E10, 1E10);\n"
 ;
 static const char COMPSHED[] =
     "    \n"


### PR DESCRIPTION
This PR should fix problems that arise when the deflection is out of bounds, `NAN` or `INF`, as reported in #143.

The slowdown was most likely caused by taking `exp()` of a too large number. The fix is applied at the pointe where the deflection is added to the position of a ray, making it unnecessary to fix every lens model individually.

before:

```
// apply deflection to ray
y -= a;
```

after:

```
// apply deflection to ray, if finite
y -= dot(a,a) < HUGE_VALF ? a : (float2)(1E10, 1E10);
```

Some testing is needed to ensure this does not affect performance, or find alternatives if it does.
