### PR TITLE
fix invalid memory being freed by options

### DIFF
--- a/src/input/options.c
+++ b/src/input/options.c
@@ -211,8 +211,9 @@ options* create_options()
 
 void free_options(options* opts)
 {
-    for(int i = 0; i < NOPTIONS; ++i)
-        OPTIONS[i].free((char*)opts + OPTIONS[i].offset);
+    // TODO: free options only when they were set, and when they are reset
+    //for(int i = 0; i < NOPTIONS; ++i)
+    //    OPTIONS[i].free((char*)opts + OPTIONS[i].offset);
     free(opts);
 }
 

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -83,7 +83,7 @@ static const char COMPLENS[] =
 static const char COMPDEFL[] =
     "    \n"
     "    // apply deflection to ray, if finite\n"
-    "    y -= dot(a,a) < HUGE_VALF ? a : (float2)(1E10, 1E10);\n"
+    "    y -= dot(a,a) < HUGE_VALF ? a : (float2)(1E10f, 1E10f);\n"
 ;
 static const char COMPSHED[] =
     "    \n"


### PR DESCRIPTION
This PR addresses bug #156. Memory of options is simply never freed, as we are losing only a few bytes there. Also, when overwriting options, the memory was not freed either. We can address this in the future, for now the "leak" is better than a segfault on exit.
