### PR TITLE
Travis: build only pushes to master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ os:
 - osx
 notifications:
   email: false
+branches:
+  only:
+    - master
 before_install:
 - case "$TRAVIS_OS_NAME" in
   linux)


### PR DESCRIPTION
This PR changes the Travis script to build only pushes to the master branch (i.e. merges) and not other branches. This prevents duplicate builds when PRs are opened.