### PR TITLE
show feedback from MultiNest

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,6 +78,7 @@ Option     | Type           | Description                            | Default
 `tol`      | `real`         | Tolerance in log-evidence.             | `0.1`
 `shf`      | `real`         | Shrinking factor.                      | `0.8`
 `maxmodes` | `int`          | Maximum number of expected modes.      | `100`
+`feedback` | `bool`         | Show feedback from MultiNest.          | `false`
 `updint`   | `int`          | Update interval for output.            | `1000`
 `seed`     | `int`          | Random number seed for sampling.       | `-1`
 `resume`   | `bool`         | Resume from last checkpoint.           | `false`

--- a/src/input.h
+++ b/src/input.h
@@ -30,6 +30,7 @@ typedef struct
     double tol;
     double shf;
     int maxmodes;
+    int feedback;
     int updint;
     int seed;
     int resume;

--- a/src/input/options.c
+++ b/src/input/options.c
@@ -166,6 +166,12 @@ struct option OPTIONS[] = {
         OPTION_FIELD(maxmodes)
     },
     {
+        "feedback",
+        "Show feedback from MultiNest",
+        OPTION_OPTIONAL(bool, 0),
+        OPTION_FIELD(feedback)
+    },
+    {
         "updint",
         "Update interval for output",
         OPTION_OPTIONAL(int, 1000),

--- a/src/log.h
+++ b/src/log.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <stdio.h>
-
 // the individual levels of logging
 extern enum log_level
 {
@@ -12,6 +10,11 @@ extern enum log_level
     LOG_ERROR,
     LOG_QUIET
 } LOG_LEVEL;
+
+// some output codes for Unix-like terminals
+#define LOG_BOLD "\033[1m"
+#define LOG_DARK "\033[2m"
+#define LOG_RESET "\033[0m"
 
 // set the log level
 void log_level(enum log_level);
@@ -37,10 +40,8 @@ void errori(const char* msg, ...);
 // print an internal error message in a file and exit
 void errorfi(const char* file, size_t line, const char* msg, ...);
 
-// redirect standard output to logfile, restore stdout when NULL is passed
-void logfile(FILE* f);
+// mute standard output
+void mute();
 
-// some output codes for Unix-like terminals
-#define LOG_BOLD "\033[1m"
-#define LOG_DARK "\033[2m"
-#define LOG_RESET "\033[0m"
+// unmute standard output
+void unmute();


### PR DESCRIPTION
This PR enables the feedback from MultiNest to be shown in Lensed's output.

```
  _                             _  ___
 | |                           | |/   \
 | |     ___ _ __  ___  ___  __| |  A  \  Lensed 1.0.0
 | |    / _ \ '_ \/ __|/ _ \/ _` | < > |
 | |___|  __/ | | \__ \  __/ (_| |  V  /  http://glenco.github.io/lensed/
 |______\___|_| |_|___/\___|\__,_|\___/ 
                                  
find posterior
  
 *****************************************************
 MultiNest v3.8
 Copyright Farhan Feroz & Mike Hobson
 Release Oct 2014

 no. of live points =  300
 dimensionality =   10
 running in constant efficiency mode
 *****************************************************
 ln(ev)=  -1.0112938543613975E-007 +/-   1.6040398497257838E-009
 Total Likelihood Evaluations:          300
 Sampling finished. Exiting MultiNest
  
done in 00:00:01
```

It introduces a new option `feedback` that corresponds directly to MultiNest's feedback flag, enabling the printing of progress while the parameter space is searched.

```
...
find posterior
  
 *****************************************************
 MultiNest v3.8
 Copyright Farhan Feroz & Mike Hobson
 Release Oct 2014

 no. of live points =  300
 dimensionality =   10
 running in constant efficiency mode
 *****************************************************
 Starting MultiNest
 generating live points
 live points generated, starting sampling
Acceptance Rate:                        1.000000
Replacements:                                300
Total Samples:                               300
Nested Sampling ln(Z):            **************
Importance Nested Sampling ln(Z):      -0.000000 +/-       NaN
...
```

All in all, this makes the code a little bit cleaner (no dangling file pointer on exit), and it's nice to have some indication that the code has not crashed.