### PR TITLE
support for extra weight map

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,7 @@ Option     | Type           | Description                            | Default
 `gain`     | `real`, `path` | [Conversion factor to counts.](#gain)  | 
 `offset`   | `real`         | Subtracted flat-field offset.          | `0`
 `weight`   | `path`         | Weight map in 1/(counts/sec)^2.        | `none`
+`xweight`  | `path`         | Extra weight map multiplier.           | `none`
 `mask`     | `path`         | Input mask, FITS file.                 | `none`
 `psf`      | `path`         | Point-spread function, FITS file.      | `none`
 `nlive`    | `int`          | Number of live points.                 | `300`

--- a/src/data.c
+++ b/src/data.c
@@ -244,6 +244,19 @@ void make_weight(const cl_float* image, const double* gain, double offset, size_
     *weight = w;
 }
 
+void read_xweight(const char* filename, size_t width, size_t height, double** xweight)
+{
+    // extra weight width and height
+    size_t xwht_w, xwht_h;
+    
+    // read extra weights from FITS file
+    read_fits(filename, TDOUBLE, &xwht_w, &xwht_h, (void**)xweight);
+    
+    // make sure dimensions agree
+    if(xwht_w != width || xwht_h != height)
+        errorf(filename, 0, "wrong dimensions %zu x %zu for extra weights (should be %zu x %zu)", xwht_w, xwht_h, width, height);
+}
+
 void read_mask(const char* filename, size_t width, size_t height, int** mask)
 {
     // mask width and height

--- a/src/data.h
+++ b/src/data.h
@@ -27,6 +27,9 @@ void read_weight(const char* filename, size_t width, size_t height, cl_float** w
 // generate weights from image, gain and offset
 void make_weight(const cl_float* image, const double* gain, double offset, size_t width, size_t height, cl_float** weight);
 
+// read extra weights from file
+void read_xweight(const char* filename, size_t width, size_t height, double** weight);
+
 // read mask from file
 void read_mask(const char* filename, size_t width, size_t height, int** mask);
 

--- a/src/input.h
+++ b/src/input.h
@@ -34,6 +34,7 @@ typedef struct
     // data
     char* image;
     char* weight;
+    char* xweight;
     char* mask;
     char* psf;
     double offset;

--- a/src/input/options.c
+++ b/src/input/options.c
@@ -104,6 +104,12 @@ struct option OPTIONS[] = {
         OPTION_FIELD(weight)
     },
     {
+        "xweight",
+        "Extra weight map multiplier",
+        OPTION_OPTIONAL(path, NULL),
+        OPTION_FIELD(xweight)
+    },
+    {
         "mask",
         "Input mask, FITS file",
         OPTION_OPTIONAL(path, NULL),


### PR DESCRIPTION
This PR introduces a new option `xweight`, similar to the `mask` parameter, that allows the user to pass a FITS file with extra weight map multipliers for each pixel.
