### PR TITLE
copy parameter info as plain old data array

### DIFF
--- a/kernel/object.cl
+++ b/kernel/object.cl
@@ -7,7 +7,7 @@ enum
 };
 
 // structure that holds parameter definition
-struct  __attribute__ ((aligned(4))) param
+struct param
 {
-    char name[32];
+    constant char* name;
 };

--- a/src/input.h
+++ b/src/input.h
@@ -44,7 +44,7 @@ typedef struct prior prior;
 typedef struct
 {
     // name of parameter
-    char name[32];
+    const char* name;
     
     // identifier of parameter
     const char* id;

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -49,12 +49,17 @@ static const char METAKERN[] =
 
 // kernel to get parameters for object
 static const char PARSKERN[] = 
-    "kernel void params_<name>(global struct param* par)\n"
+    "kernel void params_<name>(global char* names, uint n)\n"
     "{\n"
     "    for(size_t i = 0; i < sizeof(parlst_<name>)/sizeof(struct param); ++i)\n"
     "    {\n"
-    "        for(size_t j = 0; j < sizeof(par[i].name); ++j)\n"
-    "            par[i].name[j] = parlst_<name>[i].name[j];\n"
+    "        // copy names\n"
+    "        {\n"
+    "            constant char* src = parlst_<name>[i].name;\n"
+    "            for(size_t j = 0; *src != '\\0' && j < n - 1; ++j)\n"
+    "                *(names++) = *(src++);\n"
+    "            *(names++) = '\\0';\n"
+    "        }\n"
     "    }\n"
     "}\n"
 ;


### PR DESCRIPTION
This PR contains an improvement in how the information about parameters (currently only name) is passed from the OpenCL object definition to the host machine.

Instead of copying a struct with the information, the data is now stored in an array. This prevents struct alignment issues when the host or OpenCL compiler ignores the packing instructions.