### PR TITLE
add Makefile option for debug builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@
 #   EXTRA_LIBS                                                       #
 #     additional libraries                                           #
 #                                                                    #
+#   DEBUG                                                            #
+#     build with debug symbols and no optimisation                   #
+#                                                                    #
 # variables are cached in build/cache.mk                             #
 ######################################################################
 
@@ -103,9 +106,18 @@ endif
 -include build/cache.mk
 
 # general settings
-CFLAGS = -std=c99 -Wall -Werror -O3 -pedantic
+CFLAGS = -std=c99 -Wall -Werror -pedantic
 LDFLAGS = 
 LDLIBS = 
+
+# debug or release settings
+ifdef DEBUG
+CFLAGS += -O0 -g -DLENSED_DEBUG
+DEBUG_TAG = " [debug]"
+else
+CFLAGS += -O3
+DEBUG_TAG = 
+endif
 
 # CFITSIO library
 CFITSIO_LIB ?= -lcfitsio
@@ -211,7 +223,7 @@ distclean: clean
 	@$(RM) -r $(BUILD_DIR) $(BIN_DIR)
 
 $(OBJECTS): $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.c $(VERSION)
-	@$(ECHO) "building $(STYLE_BOLD)$<$(STYLE_RESET)"
+	@$(ECHO) "building $(STYLE_BOLD)$<$(STYLE_RESET)$(DEBUG_TAG)"
 	@$(MKDIR) $(@D)
 	@$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 
@@ -240,6 +252,7 @@ cache:
 	@$(ECHO) "OPENCL_LIB_DIR = $(OPENCL_LIB_DIR)" >> $(CACHE)
 	@$(ECHO) "OPENCL_LIB = $(OPENCL_LIB)" >> $(CACHE)
 	@$(ECHO) "EXTRA_LIBS = $(EXTRA_LIBS)" >> $(CACHE)
+	@$(ECHO) "DEBUG = $(DEBUG)" >> $(CACHE)
 
 show-cache:
 	@$(CAT) $(CACHE)

--- a/docs/building.md
+++ b/docs/building.md
@@ -125,6 +125,7 @@ The following variables can be passed to Lensed:
 | `OPENCL_LIB_DIR`        | path to the OpenCL library                        |
 | `OPENCL_LIB`            | OpenCL runtime library (e.g. `-lOpenCL`)          |
 | `EXTRA_LIBS`            | additional libraries and linker flags             |
+| `DEBUG`                 | build with debug symbols and no optimisation      |
 
 The values of these variables are cached in a file `build/cache.mk` and do not
 have to be repeated on subsequent calls to make. The contents of the cache can
@@ -143,11 +144,18 @@ OPENCL_INCLUDE_DIR =
 OPENCL_LIB_DIR = 
 OPENCL_LIB = -framework OpenCL
 EXTRA_LIBS = 
+DEBUG = 
 ```
 
 Please note that the `XYZ_INCLUDE_DIR` and `XYZ_LIB_DIR` variables override the
 value of the corresponding `XYZ_DIR` variable, so either the former two or the
 latter should be set.
+
+The debug build can be enabled by defining the `DEBUG` symbol, for example by
+calling `make DEBUG=1`. To disable the debug build, the `DEBUG` symbol has to
+be undefined by calling `make DEBUG=` (i.e. with no value). Debug symbols and
+optimisations are set for each individual object file at compile time, hence
+it is necessary to perform a `make clean` in order to fully apply the setting.
 
 The following sections contain further details on configuring the individual
 components of Lensed.

--- a/src/input.c
+++ b/src/input.c
@@ -14,12 +14,19 @@
 // default config file
 const char DEFAULT_INI[] = "default.ini";
 
+// tag for build type
+#ifdef LENSED_DEBUG
+const char* LENSED_BUILD_TAG = " (debug build)";
+#else
+const char* LENSED_BUILD_TAG = "";
+#endif
+
 // print usage help
 void usage(int help)
 {
     if(help)
     {
-        printf("Lensed %s\n", LENSED_VERSION);
+        printf("Lensed %s%s\n", LENSED_VERSION, LENSED_BUILD_TAG);
         printf("\n");
         printf("Reconstruct lenses and sources from observations.\n");
         printf("\n");
@@ -63,7 +70,7 @@ void usage(int help)
 // show version number and exit
 void version()
 {
-    printf("Lensed %s\n", LENSED_VERSION);
+    printf("Lensed %s%s\n", LENSED_VERSION, LENSED_BUILD_TAG);
     exit(EXIT_SUCCESS);
 }
 


### PR DESCRIPTION
This PR adds the option to perform a debug build using

    $ make DEBUG=1

The setting of `DEBUG` is cached, so that subsequent builds will continue to be in debug mode. To go back to release builds, undefine the `DEBUG` symbols as follows.

    $ make DEBUG=

(Setting it to zero won't disable debug builds.)