### PR TITLE
remove no longer necessary .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-src/*       linguist-language=C
-kernel/*    linguist-language=OpenCL


### PR DESCRIPTION
GitHub now detects the file types correctly, so the .gitattributes file is no longer necessary.