### PR TITLE
parameter types and bounds

### DIFF
--- a/kernel/object.cl
+++ b/kernel/object.cl
@@ -21,7 +21,7 @@ enum
 // structure that holds parameter definition
 struct param
 {
-    char   name[32];
+    char   name[16];
     int    type;
     float2 bounds;
 };

--- a/kernel/object.cl
+++ b/kernel/object.cl
@@ -21,6 +21,7 @@ enum
 // structure that holds parameter definition
 struct param
 {
-    char name[32];
-    int  type;
+    char   name[32];
+    int    type;
+    float2 bounds;
 };

--- a/kernel/object.cl
+++ b/kernel/object.cl
@@ -6,8 +6,21 @@ enum
     FOREGROUND = 'F'
 };
 
+// parameter types
+enum
+{
+    PARAMETER = 0,
+    POSITION_X,
+    POSITION_Y,
+    RADIUS,
+    MAGNITUDE,
+    AXIS_RATIO,
+    POS_ANGLE
+};
+
 // structure that holds parameter definition
 struct param
 {
-    constant char* name;
+    char name[32];
+    int  type;
 };

--- a/objects/devauc.cl
+++ b/objects/devauc.cl
@@ -7,12 +7,12 @@ type = SOURCE;
 
 params
 {
-    { "x" },
-    { "y" },
-    { "r" },
-    { "mag" },
-    { "q" },
-    { "pa" },
+    { "x",      POSITION_X  },
+    { "y",      POSITION_Y  },
+    { "r",      RADIUS      },
+    { "mag",    MAGNITUDE   },
+    { "q",      AXIS_RATIO  },
+    { "pa",     POS_ANGLE   },
 };
 
 data

--- a/objects/eplp.cl
+++ b/objects/eplp.cl
@@ -4,12 +4,12 @@ type = LENS;
 
 params
 {
-    { "x" },
-    { "y" },
-    { "re" },
-    { "alpha" },
-    { "q" },
-    { "pa" }
+    { "x",      POSITION_X  },
+    { "y",      POSITION_Y  },
+    { "re",     RADIUS      },
+    { "alpha",  PARAMETER   },
+    { "q",      AXIS_RATIO  },
+    { "pa",     POS_ANGLE   }
 };
 
 data

--- a/objects/eplp_plus_shear.cl
+++ b/objects/eplp_plus_shear.cl
@@ -5,14 +5,14 @@ type = LENS;
 
 params
 {
-    { "x" },
-    { "y" },
-    { "re" },
-    { "alpha" },
-    { "q" },
-    { "pa" },
-    { "g1" },
-    { "g2" }
+    { "x",      POSITION_X  },
+    { "y",      POSITION_Y  },
+    { "re",     RADIUS      },
+    { "alpha",  PARAMETER   },
+    { "q",      AXIS_RATIO  },
+    { "pa",     POS_ANGLE   },
+    { "g1",     PARAMETER   },
+    { "g2",     PARAMETER   }
 };
 
 data

--- a/objects/exponential.cl
+++ b/objects/exponential.cl
@@ -2,12 +2,12 @@ type = SOURCE;
 
 params
 {
-    { "x" },
-    { "y" },
-    { "rs" },
-    { "mag" },
-    { "q" },
-    { "pa" },
+    { "x",      POSITION_X  },
+    { "y",      POSITION_Y  },
+    { "rs",     RADIUS      },
+    { "mag",    MAGNITUDE   },
+    { "q",      AXIS_RATIO  },
+    { "pa",     POS_ANGLE   }
 };
 
 data

--- a/objects/gauss.cl
+++ b/objects/gauss.cl
@@ -2,12 +2,12 @@ type = SOURCE;
 
 params
 {
-    { "x" },
-    { "y" },
-    { "sigma" },
-    { "mag" },
-    { "q" },
-    { "pa" },
+    { "x",      POSITION_X  },
+    { "y",      POSITION_Y  },
+    { "sigma",  RADIUS      },
+    { "mag",    MAGNITUDE   },
+    { "q",      AXIS_RATIO  },
+    { "pa",     POS_ANGLE   }
 };
 
 data

--- a/objects/nsie.cl
+++ b/objects/nsie.cl
@@ -5,12 +5,12 @@ type = LENS;
 
 params
 {
-    { "x" },
-    { "y" },
-    { "r" },
-    { "rc" },
-    { "q" },
-    { "pa" }
+    { "x",  POSITION_X  },
+    { "y",  POSITION_Y  },
+    { "r",  RADIUS      },
+    { "rc", RADIUS      },
+    { "q",  AXIS_RATIO  },
+    { "pa", POS_ANGLE   }
 };
 
 data

--- a/objects/nsis.cl
+++ b/objects/nsis.cl
@@ -5,10 +5,10 @@ type = LENS;
 
 params
 {
-    { "x" },
-    { "y" },
-    { "r" },
-    { "rc" }
+    { "x",  POSITION_X  },
+    { "y",  POSITION_Y  },
+    { "r",  RADIUS      },
+    { "rc", RADIUS      }
 };
 
 data

--- a/objects/point_mass.cl
+++ b/objects/point_mass.cl
@@ -4,9 +4,9 @@ type = LENS;
 
 params
 {
-    { "x" },
-    { "y" },
-    { "r" }
+    { "x",  POSITION_X  },
+    { "y",  POSITION_Y  },
+    { "r",  RADIUS      }
 };
 
 data

--- a/objects/sersic.cl
+++ b/objects/sersic.cl
@@ -2,13 +2,13 @@ type = SOURCE;
 
 params
 {
-    { "x",      POSITION_X  },
-    { "y",      POSITION_Y  },
-    { "r",      RADIUS      },
-    { "mag",    MAGNITUDE   },
-    { "n",      PARAMETER   },
-    { "q",      AXIS_RATIO  },
-    { "pa",     POS_ANGLE   }
+    { "x",   POSITION_X },
+    { "y",   POSITION_Y },
+    { "r",   RADIUS     },
+    { "mag", MAGNITUDE  },
+    { "n",   PARAMETER, { 0.5f, 8.0f } },
+    { "q",   AXIS_RATIO },
+    { "pa",  POS_ANGLE  }
 };
 
 data

--- a/objects/sersic.cl
+++ b/objects/sersic.cl
@@ -2,13 +2,13 @@ type = SOURCE;
 
 params
 {
-    { "x" },
-    { "y" },
-    { "r" },
-    { "mag" },
-    { "n" },
-    { "q" },
-    { "pa" }
+    { "x",      POSITION_X  },
+    { "y",      POSITION_Y  },
+    { "r",      RADIUS      },
+    { "mag",    MAGNITUDE   },
+    { "n",      PARAMETER   },
+    { "q",      AXIS_RATIO  },
+    { "pa",     POS_ANGLE   }
 };
 
 data

--- a/objects/sie.cl
+++ b/objects/sie.cl
@@ -5,11 +5,11 @@ type = LENS;
 
 params
 {
-    { "x" },
-    { "y" },
-    { "r" },
-    { "q" },
-    { "pa" }
+    { "x",  POSITION_X  },
+    { "y",  POSITION_Y  },
+    { "r",  RADIUS      },
+    { "q",  AXIS_RATIO  },
+    { "pa", POS_ANGLE   }
 };
 
 data

--- a/objects/sie_plus_shear.cl
+++ b/objects/sie_plus_shear.cl
@@ -5,13 +5,13 @@ type = LENS;
 
 params
 {
-    { "x" },
-    { "y" },
-    { "r" },
-    { "q" },
-    { "pa" },
-    { "g1" },
-    { "g2" }
+    { "x",  POSITION_X  },
+    { "y",  POSITION_Y  },
+    { "r",  RADIUS      },
+    { "q",  AXIS_RATIO  },
+    { "pa", POS_ANGLE   },
+    { "g1", PARAMETER   },
+    { "g2", PARAMETER   }
 };
 
 data

--- a/objects/sis.cl
+++ b/objects/sis.cl
@@ -5,9 +5,9 @@ type = LENS;
 
 params
 {
-    { "x" },
-    { "y" },
-    { "r" }
+    { "x",  POSITION_X  },
+    { "y",  POSITION_Y  },
+    { "r",  RADIUS      }
 };
 
 data

--- a/objects/sis_plus_shear.cl
+++ b/objects/sis_plus_shear.cl
@@ -4,11 +4,11 @@ type = LENS;
 
 params
 {
-    { "x" },
-    { "y" },
-    { "r" },
-    { "g1" },
-    { "g2" }
+    { "x",  POSITION_X  },
+    { "y",  POSITION_Y  },
+    { "r",  RADIUS      },
+    { "g1", PARAMETER   },
+    { "g2", PARAMETER   }
 };
 
 data

--- a/src/input.c
+++ b/src/input.c
@@ -269,7 +269,7 @@ void print_input(const input* inp)
                 print_prior(inp->objs[i].pars[j].pri, buf, 99);
                 
                 // collect tags
-                snprintf(tag, 100, " [%s%s%s%s%s%s%s",
+                snprintf(tag, 100, " [%s%s%s%s%s%s%s%s",
                     inp->objs[i].pars[j].type == PAR_POSITION_X ?
                         "position x, " : "",
                     inp->objs[i].pars[j].type == PAR_POSITION_Y ?
@@ -282,6 +282,8 @@ void print_input(const input* inp)
                         "axis ratio, " : "",
                     inp->objs[i].pars[j].type == PAR_POS_ANGLE ?
                         "pos. angle, " : "",
+                    inp->objs[i].pars[j].bounded ?
+                        "bounded, " : "",
                     inp->objs[i].pars[j].wrap ?
                         "wrap, " : ""
                 );

--- a/src/input.c
+++ b/src/input.c
@@ -258,14 +258,50 @@ void print_input(const input* inp)
         {
             for(size_t j = 0; j < inp->objs[i].npars; ++j, ++p)
             {
+                const char* label;
                 char buf[100] = {0};
+                char tag[100] = {0};
+                
+                // set label, or id if no label set
+                label = inp->objs[i].pars[j].label ? inp->objs[i].pars[j].label : inp->objs[i].pars[j].id;
+                
+                // pretty-print prior
                 print_prior(inp->objs[i].pars[j].pri, buf, 99);
                 
-                verbose("  %zu: %s ~ %s%s", p,
-                        inp->objs[i].pars[j].label ? inp->objs[i].pars[j].label
-                                                   : inp->objs[i].pars[j].id,
-                        buf,
-                        inp->objs[i].pars[j].wrap ? " [wrapped]" : "");
+                // collect tags
+                snprintf(tag, 100, " [%s%s%s%s%s%s%s",
+                    inp->objs[i].pars[j].type == PAR_POSITION_X ?
+                        "position x, " : "",
+                    inp->objs[i].pars[j].type == PAR_POSITION_Y ?
+                        "position y, " : "",
+                    inp->objs[i].pars[j].type == PAR_RADIUS ?
+                        "radius, " : "",
+                    inp->objs[i].pars[j].type == PAR_MAGNITUDE ?
+                        "magnitude, " : "",
+                    inp->objs[i].pars[j].type == PAR_AXIS_RATIO ?
+                        "axis ratio, " : "",
+                    inp->objs[i].pars[j].type == PAR_POS_ANGLE ?
+                        "pos. angle, " : "",
+                    inp->objs[i].pars[j].wrap ?
+                        "wrap, " : ""
+                );
+                
+                // check if tags were set
+                if(strcmp(tag, " [") == 0)
+                {
+                    // no tags, empty string
+                    *tag = '\0';
+                }
+                else
+                {
+                    // terminate tags
+                    size_t len = strlen(tag);
+                    tag[len-1] = '\0';
+                    tag[len-2] = ']';
+                }
+                
+                // output line for parameter
+                verbose("  %zu: %s ~ %s%s", p, label, buf, tag);
             }
         }
     }

--- a/src/input.h
+++ b/src/input.h
@@ -72,6 +72,11 @@ typedef struct
     // type of parameter
     int type;
     
+    // hard parameter bounds
+    double lower;
+    double upper;
+    int bounded;
+    
     // prior for parameter
     prior* pri;
     

--- a/src/input.h
+++ b/src/input.h
@@ -1,5 +1,25 @@
 #pragma once
 
+// object types
+enum
+{
+    OBJ_LENS       = 'L',
+    OBJ_SOURCE     = 'S',
+    OBJ_FOREGROUND = 'F'
+};
+
+// parameter types
+enum
+{
+    PAR_PARAMETER = 0,
+    PAR_POSITION_X,
+    PAR_POSITION_Y,
+    PAR_RADIUS,
+    PAR_MAGNITUDE,
+    PAR_AXIS_RATIO,
+    PAR_POS_ANGLE
+};
+
 // options
 typedef struct
 {
@@ -49,23 +69,18 @@ typedef struct
     // identifier of parameter
     const char* id;
     
-    // label, used for output
-    const char* label;
+    // type of parameter
+    int type;
     
     // prior for parameter
     prior* pri;
     
     // flag for wrap-around parameters
     int wrap;
+    
+    // label, used for output
+    const char* label;
 } param;
-
-// object types
-enum
-{
-    OBJ_LENS       = 'L',
-    OBJ_SOURCE     = 'S',
-    OBJ_FOREGROUND = 'F'
-};
 
 // definition of objects
 typedef struct

--- a/src/input/objects.c
+++ b/src/input/objects.c
@@ -11,8 +11,6 @@
 
 static const char* WS = " \t\n\v\f\r";
 
-static const cl_uint MAX_PAR_NAME = 32;
-
 void add_object(input* inp, const char* id, const char* name)
 {
     object* obj;
@@ -24,19 +22,30 @@ void add_object(input* inp, const char* id, const char* name)
     cl_program program;
     size_t nkernels;
     const char** kernels;
-    cl_mem meta_type_mem;
-    cl_mem meta_size_mem;
-    cl_mem meta_npars_mem;
-    char* meta_name;
-    cl_kernel meta_kernel;
-    cl_int meta_type;
-    cl_ulong meta_size;
-    cl_ulong meta_npars;
-    char* param_kernam;
-    cl_kernel param_kernel;
-    cl_mem param_names_mem;
-    cl_char* param_names;
-    cl_char* param_cur_name;
+    
+    // object metadata kernel
+    char*       meta_kernam;
+    cl_kernel   meta_kernel;
+    
+    // object metadata
+    cl_mem      meta_type_mem;
+    cl_int      meta_type;
+    cl_mem      meta_size_mem;
+    cl_ulong    meta_size;
+    cl_mem      meta_npar_mem;
+    cl_ulong    meta_npar;
+    cl_mem      meta_nnam_mem;
+    cl_ulong    meta_nnam;
+    
+    // parameter info kernel
+    char*       param_kernam;
+    cl_kernel   param_kernel;
+    
+    // parameter information
+    cl_mem      param_names_mem;
+    cl_char*    param_names;
+    cl_mem      param_types_mem;
+    cl_int*     param_types;
     
     // realloc space for one more object
     inp->nobjs += 1;
@@ -61,7 +70,7 @@ void add_object(input* inp, const char* id, const char* name)
     if(err != CL_SUCCESS)
         error("object %s: failed to create command queue", id);
     
-    // load kernel for object meta-data
+    // load kernel for object metadata
     object_program(name, &nkernels, &kernels);
     
     // create the program from kernel sources
@@ -94,46 +103,50 @@ void add_object(input* inp, const char* id, const char* name)
         free((char*)build_options);
     }
     
-    // buffers for object meta-data
+    // buffers for object metadata
     meta_type_mem = clCreateBuffer(lcl->context, CL_MEM_WRITE_ONLY, sizeof(cl_int), NULL, NULL);
     meta_size_mem = clCreateBuffer(lcl->context, CL_MEM_WRITE_ONLY, sizeof(cl_ulong), NULL, NULL);
-    meta_npars_mem = clCreateBuffer(lcl->context, CL_MEM_WRITE_ONLY, sizeof(cl_ulong), NULL, NULL);
-    if(!meta_type_mem || !meta_size_mem || !meta_npars_mem)
-        error("object %s: failed to create buffer for meta-data", id);
+    meta_npar_mem = clCreateBuffer(lcl->context, CL_MEM_WRITE_ONLY, sizeof(cl_ulong), NULL, NULL);
+    meta_nnam_mem = clCreateBuffer(lcl->context, CL_MEM_WRITE_ONLY, sizeof(cl_ulong), NULL, NULL);
+    if(!meta_type_mem || !meta_size_mem || !meta_npar_mem || !meta_nnam_mem)
+        error("object %s: failed to create buffer for metadata", id);
     
     // setup and run kernel to get meta_data
-    meta_name = kernel_name("meta_", name);
-    meta_kernel = clCreateKernel(program, meta_name, &err);
+    meta_kernam = kernel_name("meta_", name);
+    meta_kernel = clCreateKernel(program, meta_kernam, &err);
     if(err != CL_SUCCESS)
-        error("object %s: failed to create kernel for meta-data", id);
+        error("object %s: failed to create kernel for metadata", id);
     err |= clSetKernelArg(meta_kernel, 0, sizeof(cl_mem), &meta_type_mem);
     err |= clSetKernelArg(meta_kernel, 1, sizeof(cl_mem), &meta_size_mem);
-    err |= clSetKernelArg(meta_kernel, 2, sizeof(cl_mem), &meta_npars_mem);
+    err |= clSetKernelArg(meta_kernel, 2, sizeof(cl_mem), &meta_npar_mem);
+    err |= clSetKernelArg(meta_kernel, 3, sizeof(cl_mem), &meta_nnam_mem);
     if(err != CL_SUCCESS)
-        error("object %s: failed to set kernel arguments for meta-data", id);
+        error("object %s: failed to set kernel arguments for metadata", id);
     err = clEnqueueTask(queue, meta_kernel, 0, NULL, NULL);
     if(err != CL_SUCCESS)
-        error("object %s: failed to run kernel for meta-data", id);
+        error("object %s: failed to run kernel for metadata", id);
     
-    // get meta-data from buffer
-    err |= clEnqueueReadBuffer(queue, meta_type_mem, CL_TRUE, 0, sizeof(cl_int), &meta_type, 0, NULL, NULL);
+    // get metadata from buffer
+    err |= clEnqueueReadBuffer(queue, meta_type_mem, CL_TRUE, 0, sizeof(cl_int),   &meta_type, 0, NULL, NULL);
     err |= clEnqueueReadBuffer(queue, meta_size_mem, CL_TRUE, 0, sizeof(cl_ulong), &meta_size, 0, NULL, NULL);
-    err |= clEnqueueReadBuffer(queue, meta_npars_mem, CL_TRUE, 0, sizeof(cl_ulong), &meta_npars, 0, NULL, NULL);
+    err |= clEnqueueReadBuffer(queue, meta_npar_mem, CL_TRUE, 0, sizeof(cl_ulong), &meta_npar, 0, NULL, NULL);
+    err |= clEnqueueReadBuffer(queue, meta_nnam_mem, CL_TRUE, 0, sizeof(cl_ulong), &meta_nnam, 0, NULL, NULL);
     if(err != CL_SUCCESS)
-        error("object %s: failed to get meta-data", id);
+        error("object %s: failed to get metadata", id);
     
-    // set meta-data for object
-    obj->type = meta_type;
-    obj->size = meta_size;
-    obj->npars = meta_npars;
+    // set metadata for object
+    obj->type  = meta_type;
+    obj->size  = meta_size;
+    obj->npars = meta_npar;
     
-    // check meta-data
+    // check metadata
     if(obj->type != OBJ_LENS && obj->type != OBJ_SOURCE && obj->type != OBJ_FOREGROUND)
         error("object %s: invalid type (should be LENS, SOURCE or FOREGROUND)", id);
     
     // buffers for kernel parameters
-    param_names_mem = clCreateBuffer(lcl->context, CL_MEM_WRITE_ONLY, obj->npars*MAX_PAR_NAME*sizeof(cl_char), NULL, NULL);
-    if(!param_names_mem)
+    param_names_mem  = clCreateBuffer(lcl->context, CL_MEM_WRITE_ONLY, obj->npars*meta_nnam*sizeof(cl_char), NULL, NULL);
+    param_types_mem  = clCreateBuffer(lcl->context, CL_MEM_WRITE_ONLY, obj->npars*sizeof(cl_int),            NULL, NULL);
+    if(!param_types_mem || !param_names_mem)
         error("object %s: failed to create buffer for parameters", id);
     
     // setup and run kernel to get parameters
@@ -141,8 +154,8 @@ void add_object(input* inp, const char* id, const char* name)
     param_kernel = clCreateKernel(program, param_kernam, &err);
     if(err != CL_SUCCESS)
         error("object %s: failed to create kernel for parameters", id);
-    err  = clSetKernelArg(param_kernel, 0, sizeof(cl_mem), &param_names_mem);
-    err |= clSetKernelArg(param_kernel, 1, sizeof(cl_uint), &MAX_PAR_NAME);
+    err |= clSetKernelArg(param_kernel, 0, sizeof(cl_mem), &param_names_mem );
+    err |= clSetKernelArg(param_kernel, 1, sizeof(cl_mem), &param_types_mem );
     if(err != CL_SUCCESS)
         error("object %s: failed to set kernel arguments for parameters", id);
     err = clEnqueueTask(queue, param_kernel, 0, NULL, NULL);
@@ -150,12 +163,14 @@ void add_object(input* inp, const char* id, const char* name)
         error("object %s: failed to run kernel for parameters", id);
     
     // arrays for kernel parameters
-    param_names = malloc(obj->npars*MAX_PAR_NAME*sizeof(cl_char));
-    if(!param_names)
+    param_names  = malloc(obj->npars*meta_nnam*sizeof(cl_char));
+    param_types  = malloc(obj->npars*sizeof(cl_int));
+    if(!param_types || !param_names)
         errori("object %s", id);
     
     // get kernel parameters from buffer
-    err = clEnqueueReadBuffer(queue, param_names_mem, CL_TRUE, 0, obj->npars*MAX_PAR_NAME*sizeof(cl_char), param_names, 0, NULL, NULL);
+    err |= clEnqueueReadBuffer(queue, param_names_mem,  CL_TRUE, 0, obj->npars*meta_nnam*sizeof(cl_char), param_names,  0, NULL, NULL);
+    err |= clEnqueueReadBuffer(queue, param_types_mem,  CL_TRUE, 0, obj->npars*sizeof(cl_int),            param_types,  0, NULL, NULL);
     if(err != CL_SUCCESS)
         error("object %s: failed to get parameters", id);
     
@@ -163,9 +178,6 @@ void add_object(input* inp, const char* id, const char* name)
     obj->pars = malloc(obj->npars*sizeof(param));
     if(!obj->pars)
         errori("object %s", id);
-    
-    // the current parameter name
-    param_cur_name = param_names;
     
     // set up parameter array
     for(size_t i = 0; i < obj->npars; ++i)
@@ -176,54 +188,49 @@ void add_object(input* inp, const char* id, const char* name)
         // id of parameter
         char* id;
         
-        // length of parameter name
-        size_t len = 0;
-        
-        // get length of name
-        while(param_cur_name[len] != '\0')
-            ++len;
-        
         // allocate name
-        name = malloc(len + 1);
+        name = malloc(meta_nnam);
         if(!name)
             errori(NULL);
         
-        // copy name and set in param
-        for(size_t i = 0; i <= len; ++i)
-            name[i] = param_cur_name[i];
-        obj->pars[i].name = name;
-        
-        // skip name
-        param_cur_name += len + 1;
+        // copy name
+        for(size_t j = 0; j < meta_nnam; ++j)
+            name[j] = param_names[i*meta_nnam + j];
         
         // create id
-        id = malloc(strlen(obj->id) + 1 + len + 1);
+        id = malloc(strlen(obj->id) + 1 + strlen(name) + 1);
         if(!id)
             errori(NULL);
-        sprintf(id, "%s.%s", obj->id, obj->pars[i].name);
-        obj->pars[i].id = id;
+        sprintf(id, "%s.%s", obj->id, name);
         
-        // no label is set
-        obj->pars[i].label = NULL;
-        
-        // no prior is set
-        obj->pars[i].pri = NULL;
-        
-        // no wrap-around
-        obj->pars[i].wrap = 0;
+        // set parameter information
+        obj->pars[i].name   = name;
+        obj->pars[i].id     = id;
+        obj->pars[i].type   = param_types[i];
+        obj->pars[i].pri    = NULL;
+        obj->pars[i].wrap   = 0;
+        obj->pars[i].label  = NULL;
     }
     
     // clean up
     clFinish(queue);
+    
     clReleaseMemObject(param_names_mem);
     free(param_names);
-    clReleaseKernel(param_kernel);
+    clReleaseMemObject(param_types_mem);
+    free(param_types);
+    
     free(param_kernam);
+    clReleaseKernel(param_kernel);
+    
+    free(meta_kernam);
     clReleaseKernel(meta_kernel);
-    free(meta_name);
+    
     clReleaseMemObject(meta_type_mem);
     clReleaseMemObject(meta_size_mem);
-    clReleaseMemObject(meta_npars_mem);
+    clReleaseMemObject(meta_npar_mem);
+    clReleaseMemObject(meta_nnam_mem);
+    
     for(int i = 0; i < nkernels; ++i)
         free((void*)kernels[i]);
     clReleaseProgram(program);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -53,12 +53,10 @@ static const char PARSKERN[] =
     "kernel void params_<name>(global char16* names, global int* types,\n"
     "                          global float2* bounds)\n"
     "{\n"
-    "    for(size_t i = 0; i < sizeof(parlst_<name>)/sizeof(struct param); ++i)\n"
-    "    {\n"
-    "        names[i]  = vload16(0, parlst_<name>[i].name);\n"
-    "        types[i]  = parlst_<name>[i].type;\n"
-    "        bounds[i] = parlst_<name>[i].bounds;\n"
-    "    }\n"
+    "    size_t i = get_global_id(0);\n"
+    "    names[i] = vload16(0, parlst_<name>[i].name);\n"
+    "    types[i] = parlst_<name>[i].type;\n"
+    "    bounds[i] = parlst_<name>[i].bounds;\n"
     "}\n"
 ;
 

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -39,27 +39,27 @@ static const size_t NMAINKERNS = sizeof(MAINKERNS)/sizeof(MAINKERNS[0]);
 
 // kernel to get meta-data for object
 static const char METAKERN[] = 
-    "kernel void meta_<name>(global int* type, global ulong* size, global ulong* npar)\n"
+    "kernel void meta_<name>(global int*   type, global ulong* size,\n"
+    "                        global ulong* npar, global ulong* nnam)\n"
     "{\n"
     "    *type = type_<name>;\n"
     "    *size = sizeof(struct data_<name>);\n"
     "    *npar = sizeof(parlst_<name>)/sizeof(struct param);\n"
+    "    *nnam = sizeof(((struct param*)0)->name);\n"
     "}\n"
 ;
 
 // kernel to get parameters for object
 static const char PARSKERN[] = 
-    "kernel void params_<name>(global char* names, uint n)\n"
+    "kernel void params_<name>(global char* names, global int* types)\n"
     "{\n"
-    "    for(size_t i = 0; i < sizeof(parlst_<name>)/sizeof(struct param); ++i)\n"
+    "    const size_t n = sizeof(parlst_<name>)/sizeof(struct param);\n"
+    "    const size_t l = sizeof(((struct param*)0)->name);\n"
+    "    for(size_t i = 0; i < n; ++i)\n"
     "    {\n"
-    "        // copy names\n"
-    "        {\n"
-    "            constant char* src = parlst_<name>[i].name;\n"
-    "            for(size_t j = 0; *src != '\\0' && j < n - 1; ++j)\n"
-    "                *(names++) = *(src++);\n"
-    "            *(names++) = '\\0';\n"
-    "        }\n"
+    "        for(size_t j = 0; j < l; ++j)\n"
+    "            names[i*l + j] = parlst_<name>[i].name[j];\n"
+    "        types[i] = parlst_<name>[i].type;\n"
     "    }\n"
     "}\n"
 ;

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -40,26 +40,22 @@ static const size_t NMAINKERNS = sizeof(MAINKERNS)/sizeof(MAINKERNS[0]);
 // kernel to get meta-data for object
 static const char METAKERN[] = 
     "kernel void meta_<name>(global int*   type, global ulong* size,\n"
-    "                        global ulong* npar, global ulong* nnam)\n"
+    "                        global ulong* npar)\n"
     "{\n"
     "    *type = type_<name>;\n"
     "    *size = sizeof(struct data_<name>);\n"
     "    *npar = sizeof(parlst_<name>)/sizeof(struct param);\n"
-    "    *nnam = sizeof(((struct param*)0)->name);\n"
     "}\n"
 ;
 
 // kernel to get parameters for object
 static const char PARSKERN[] = 
-    "kernel void params_<name>(global char*   names, global int* types,\n"
+    "kernel void params_<name>(global char16* names, global int* types,\n"
     "                          global float2* bounds)\n"
     "{\n"
-    "    const size_t n = sizeof(parlst_<name>)/sizeof(struct param);\n"
-    "    const size_t l = sizeof(((struct param*)0)->name);\n"
-    "    for(size_t i = 0; i < n; ++i)\n"
+    "    for(size_t i = 0; i < sizeof(parlst_<name>)/sizeof(struct param); ++i)\n"
     "    {\n"
-    "        for(size_t j = 0; j < l; ++j)\n"
-    "            names[i*l + j] = parlst_<name>[i].name[j];\n"
+    "        names[i]  = vload16(0, parlst_<name>[i].name);\n"
     "        types[i]  = parlst_<name>[i].type;\n"
     "        bounds[i] = parlst_<name>[i].bounds;\n"
     "    }\n"

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -51,7 +51,8 @@ static const char METAKERN[] =
 
 // kernel to get parameters for object
 static const char PARSKERN[] = 
-    "kernel void params_<name>(global char* names, global int* types)\n"
+    "kernel void params_<name>(global char*   names, global int* types,\n"
+    "                          global float2* bounds)\n"
     "{\n"
     "    const size_t n = sizeof(parlst_<name>)/sizeof(struct param);\n"
     "    const size_t l = sizeof(((struct param*)0)->name);\n"
@@ -59,7 +60,8 @@ static const char PARSKERN[] =
     "    {\n"
     "        for(size_t j = 0; j < l; ++j)\n"
     "            names[i*l + j] = parlst_<name>[i].name[j];\n"
-    "        types[i] = parlst_<name>[i].type;\n"
+    "        types[i]  = parlst_<name>[i].type;\n"
+    "        bounds[i] = parlst_<name>[i].bounds;\n"
     "    }\n"
     "}\n"
 ;

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -92,13 +92,62 @@ int main(int argc, char* argv[])
         for(size_t j = 0; j < inp->objs[i].npars; ++j, ++p)
             lensed.pars[p] = &inp->objs[i].pars[j];
     
-    // get all priors that will be needed when running
-    lensed.pris = malloc(lensed.npars*sizeof(prior*));
-    if(!lensed.pris)
-        errori(NULL);
-    for(size_t i = 0, p = 0; i < inp->nobjs; ++i)
-        for(size_t j = 0; j < inp->objs[i].npars; ++j, ++p)
-            lensed.pris[p] = inp->objs[i].pars[j].pri;
+    // process parameters
+    for(size_t i = 0; i < lensed.npars; ++i)
+    {
+        // current parameter
+        param* par = lensed.pars[i];
+        
+        // apply default bounds if none provided
+        if(!par->lower && !par->upper)
+        {
+            switch(par->type)
+            {
+            case PAR_RADIUS:
+                par->lower = 0;
+                par->upper = HUGE_VAL;
+                break;
+                
+            case PAR_AXIS_RATIO:
+                par->lower = 0;
+                par->upper = 1;
+                break;
+                
+            default:
+                break;
+            }
+        }
+        
+        // mark if parameter is bounded
+        par->bounded = (par->lower || par->upper);
+        
+        // check that prior is compatible with bounds
+        if(par->bounded && (prior_lower(par->pri) < par->lower || prior_upper(par->pri) > par->upper))
+        {
+            // check if there is overlap between the bounds
+            if(prior_lower(par->pri) >= par->upper || prior_upper(par->pri) <= par->lower)
+            {
+                // prior falls completely outside of allowed range
+                error("%s: prior does not include parameter bounds [%g, %g]\n"
+                      "The prior does not include the allowed range of values "
+                      "for the parameter. It is impossible to draw a valid "
+                      "parameter value. Please fix the prior to include the "
+                      "range of values indicated above.",
+                      par->id, par->lower, par->upper);
+            }
+            else
+            {
+                // prior overlaps parameter bounds, issue a warning
+                warn("%s: prior partially outside parameter bounds [%g, %g]\n"
+                     "Part of the prior lies outside of the allowed range of "
+                     "parameter values. Values will be drawn from the prior "
+                     "until a valid one is found. If the bounds of prior and "
+                     "parameter do not overlap significantly, this can be "
+                     "slow. You might want to change the prior accordingly.",
+                     par->id, par->lower, par->upper);
+            }
+        }
+    }
     
     
     /*****************

--- a/src/lensed.h
+++ b/src/lensed.h
@@ -12,7 +12,6 @@ struct lensed
     // parameter space
     size_t npars;
     param** pars;
-    prior** pris;
     
     // results
     const char* fits;

--- a/src/nested.c
+++ b/src/nested.c
@@ -18,7 +18,13 @@ void loglike(double cube[], int* ndim, int* npar, double* lnew, void* lensed_)
     
     // transform from unit cube to physical
     for(size_t i = 0; i < lensed->npars; ++i)
-        apply_prior(lensed->pris[i], &cube[i]);
+    {
+        double phys;
+        do
+            phys = apply_prior(lensed->pars[i]->pri, cube[i]);
+        while(lensed->pars[i]->bounded && (phys < lensed->pars[i]->lower || phys > lensed->pars[i]->upper));
+        cube[i] = phys;
+    }
     
     // error flag
     cl_int err = 0;

--- a/src/prior.c
+++ b/src/prior.c
@@ -164,9 +164,9 @@ void print_prior(const prior* pri, char* buf, size_t n)
     pri->print(pri->data, buf, n);
 }
 
-void apply_prior(const prior* pri, double* u)
+double apply_prior(const prior* pri, double u)
 {
-    *u = pri->prior(pri->data, *u);
+    return pri->prior(pri->data, u);
 }
 
 double prior_lower(const prior* pri)

--- a/src/prior.h
+++ b/src/prior.h
@@ -10,7 +10,7 @@ void free_prior(prior* pri);
 void print_prior(const prior* pri, char* buf, size_t n);
 
 // apply prior to unit variate
-void apply_prior(const prior* pri, double* u);
+double apply_prior(const prior* pri, double u);
 
 // get lower bound for prior
 double prior_lower(const prior* pri);

--- a/src/prior/norm.c
+++ b/src/prior/norm.c
@@ -83,10 +83,10 @@ double prior_norm(const void* data, double u)
 
 double prior_lower_norm(const void* data)
 {
-    return -INFINITY;
+    return -HUGE_VAL;
 }
 
 double prior_upper_norm(const void* data)
 {
-    return INFINITY;
+    return +HUGE_VAL;
 }


### PR DESCRIPTION
This PR introduces the possibility to give types and bounds to the individual parameters in an object definition. So far, the parameter types only serve to give a number of default bounds on parameters (see below), but they will be more useful in the future.

An example from the Sérsic source is

```c
params
{
    { "x",   POSITION_X },
    { "y",   POSITION_Y },
    { "r",   RADIUS     },
    { "mag", MAGNITUDE  },
    { "n",   PARAMETER, { 0.5f, 8.0f } },
    { "q",   AXIS_RATIO },
    { "pa",  POS_ANGLE  }
};
```

The second (optional) argument is the parameter type.
There are a number of common, predefined parameter types: `POSITION_X`, `POSITION_Y`, `RADIUS`, `MAGNITUDE`, `AXIS_RATIO`, `POS_ANGLE`.
The generic type for parameters without special, pre-defined meaning is `PARAMETER`, which is the default.

The third (optional) argument is the definition of hard bounds for the parameter. This serves to limit the possible range of parameter values, for example to exclude unphysical quantities. Lensed will check whether a prior agrees with the bounds, and display a warning if the prior is partially out of the range, or an error if it is fully out of range.

```
warning: source.n: prior partially outside parameter bounds [0.5, 8]
Part of the prior lies outside of the allowed range of parameter values. Values 
will be drawn from the prior until a valid one is found. If the bounds of prior 
and parameter do not overlap significantly, this can be slow. You might want to 
change the prior accordingly.
```
```
error: source.q: prior does not include parameter bounds [0, 1]
The prior does not include the allowed range of values for the parameter. It is 
impossible to draw a valid parameter value. Please fix the prior to include the 
range of values indicated above.
```

We can also define bounds to be set by default for certain parameter types. So far, these are

-   `RADIUS` has bounds *[0, inf)*
-   `AXIS_RATIO` has bounds *[0, 1]*
