### PR TITLE
simple profiling for OpenCL functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ HEADERS = lensed.h \
           prior.h \
           parse.h \
           path.h \
+          profile.h \
           log.h \
           input/objects.h \
           input/options.h \
@@ -79,6 +80,7 @@ SOURCES = lensed.c \
           prior.c \
           parse.c \
           path.c \
+          profile.c \
           log.c \
           input/objects.c \
           input/options.c \

--- a/src/input.c
+++ b/src/input.c
@@ -48,6 +48,7 @@ void usage(int help)
         printf("  %-16s  %s\n", "-q, --quiet", "Suppress all output.");
         printf("  %-16s  %s\n", "--version", "Show version number.");
         printf("  %-16s  %s\n", "--devices", "List computation devices.");
+        printf("  %-16s  %s\n", "--profile", "Enable OpenCL profiling.");
         printf("  %-16s  %s\n", "--batch-header", "Batch output header.");
         for(size_t i = 0, n = noptions(); i < n; ++i)
         {
@@ -170,6 +171,8 @@ input* read_input(int argc, char* argv[])
                     version();
                 else if(strcmp(argv[i]+2, "devices") == 0)
                     inp->opts->devices = 1;
+                else if(strcmp(argv[i]+2, "profile") == 0)
+                    inp->opts->profile = 1;
                 else if(strcmp(argv[i]+2, "batch-header") == 0)
                     inp->opts->batch_header = 1;
                 else

--- a/src/input.h
+++ b/src/input.h
@@ -28,6 +28,7 @@ typedef struct
     int output;
     char* root;
     int devices;
+    int profile;
     int batch_header;
     
     // data

--- a/src/lensed.h
+++ b/src/lensed.h
@@ -49,4 +49,16 @@ struct lensed
     cl_kernel loglike;
     size_t loglike_lws[1];
     size_t loglike_gws[1];
+    
+    // profiling info
+    struct {
+        profile* map_params;
+        profile* unmap_params;
+        profile* set_params;
+        profile* render;
+        profile* convolve;
+        profile* loglike;
+        profile* map_loglike_mem;
+        profile* unmap_loglike_mem;
+    }* profile;
 };

--- a/src/profile.c
+++ b/src/profile.c
@@ -1,0 +1,83 @@
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "opencl.h"
+#include "profile.h"
+#include "log.h"
+
+profile* profile_create(const char* name)
+{
+    profile* prof = malloc(sizeof(profile));
+    if(!prof)
+        errori(NULL);
+    
+    prof->name    = name;
+    prof->queue   = 0;
+    prof->submit  = 0;
+    prof->execute = 0;
+    
+    return prof;
+}
+
+void profile_free(profile* prof)
+{
+    free(prof);
+}
+
+cl_event* profile_event()
+{
+    cl_event* e = malloc(sizeof(cl_event));
+    if(!e)
+        errori(NULL);
+    return e;
+}
+
+void profile_read(profile* prof, cl_event* event)
+{
+    cl_ulong queue, submit, start, end;
+    
+    clGetEventProfilingInfo(*event, CL_PROFILING_COMMAND_QUEUED, sizeof(cl_ulong), &queue, NULL);
+    clGetEventProfilingInfo(*event, CL_PROFILING_COMMAND_SUBMIT, sizeof(cl_ulong), &submit, NULL);
+    clGetEventProfilingInfo(*event, CL_PROFILING_COMMAND_START, sizeof(cl_ulong), &start, NULL);
+    clGetEventProfilingInfo(*event, CL_PROFILING_COMMAND_END, sizeof(cl_ulong), &end, NULL);
+    
+    prof->queue   += submit - queue;
+    prof->submit  += start - submit;
+    prof->execute += end - start;
+    
+    clReleaseEvent(*event);
+    free(event);
+}
+
+void profile_print(int profc, profile* profv[])
+{
+    unsigned long long total;
+    
+    // get total ticks across all profiles
+    total = 0;
+    for(int i = 0; i < profc; ++i)
+        total += profv[i]->execute;
+    
+    // table header
+    info(LOG_BOLD "  %-12s  " LOG_DARK "%10s  %10s  %10s" LOG_RESET LOG_BOLD "  %10s  %10s" LOG_RESET,
+         "function", "queue", "submit", "execute", "per cent", "time");
+    info("  ------------------------------------------------------------------------");
+     
+    // output table
+    for(int i = 0; i < profc; ++i)
+    {
+        unsigned long long queue   = profv[i]->queue/1000000;
+        unsigned long long submit  = profv[i]->submit/1000000;
+        unsigned long long execute = profv[i]->execute/1000000;
+        
+        double percent = 100.0*profv[i]->execute/total;
+        
+        double time = 1e-9*profv[i]->execute;
+        double sec  = fmod(time, 60);
+        int    min  = floor(time/60) + 0.5;
+        
+        info("  %-12s  " LOG_DARK "%10llu  %10llu  %10llu" LOG_RESET "  %10.2f  %3d:%06.3f",
+             profv[i]->name, queue, submit, execute, percent, min, sec);
+    }
+}

--- a/src/profile.h
+++ b/src/profile.h
@@ -1,0 +1,31 @@
+#pragma once
+
+typedef struct
+{
+    // profile name
+    const char* name;
+    
+    // number of ticks between queue and submit of event
+    unsigned long long queue;
+    
+    // number of ticks between submit and start of event
+    unsigned long long submit;
+    
+    // number of ticks between start and end of event
+    unsigned long long execute;
+} profile;
+
+// create a new profile with the given name, which is not copied
+profile* profile_create(const char* name);
+
+// delete a profile
+void profile_free(profile*);
+
+// create an event for profiling
+cl_event* profile_event();
+
+// read profile data from event, freeing the event
+void profile_read(profile* prof, cl_event* event);
+
+// print table for profile
+void profile_print(int profc, profile* profv[]);


### PR DESCRIPTION
This PR implements a simple profiling of the OpenCL functions using the built-in event system. Profiling can be enabled using the `--profile` flag. A table with some profiling information will be printed at the end of the output:

```
profiler
  
  function           queue      submit     execute    per cent        time
  ------------------------------------------------------------------------
  +params                0           0           0        0.00    0:00.000
  -params                0           0           0        0.00    0:00.000
  set_params          2954        2973         515        1.61    0:00.515
  render              2021        3692       31003       96.86    0:31.003
  convolve               0           0           0        0.00    0:00.000
  loglike             1189       34888         490        1.53    0:00.490
  +loglike_mem           0           0           0        0.00    0:00.000
  -loglike_mem           0           0           0        0.00    0:00.000
  
```

The rows are the individual OpenCL functions performed in the log-likelihood calculation, where `+`/`-` indicates mapping/unmapping of a buffer. The `queue`, `submit`, and `execute` columns give the number of ticks (in ms) the function spent in the command queue, for submission, and for execution, respectively. The `per cent` and `time` columns give the respective quantities for the execution time of the function.