### PR TITLE
minor output tweak for help display and device list

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -33,29 +33,32 @@ void usage(int help)
     }
     
     printf("Usage:\n");
-    printf("  lensed ([<file>] | [options])...\n");
+    printf("  lensed [flags] ([<file>] | [options])...\n");
     printf("  lensed -h | --help\n");
     
     if(help)
     {
         printf("\n");
+        printf("Flags:\n");
+        printf("  %-20s  %s\n", "-h, --help", "Show this help message.");
+        printf("  %-20s  %s\n", "-v, --verbose", "Verbose output.");
+        printf("  %-20s  %s\n", "--warn", "Show only warnings and errors.");
+        printf("  %-20s  %s\n", "--error", "Show only errors.");
+        printf("  %-20s  %s\n", "-b, --batch", "Batch output.");
+        printf("  %-20s  %s\n", "-q, --quiet", "Suppress all output.");
+        printf("  %-20s  %s\n", "--version", "Show version number.");
+        printf("  %-20s  %s\n", "--devices", "List computation devices.");
+        printf("  %-20s  %s\n", "--profile", "Enable OpenCL profiling.");
+        printf("  %-20s  %s\n", "--batch-header", "Batch output header.");
+        
+        printf("\n");
         printf("Options:\n");
-        printf("  %-16s  %s\n", "-h, --help", "Show this help message.");
-        printf("  %-16s  %s\n", "-v, --verbose", "Verbose output.");
-        printf("  %-16s  %s\n", "--warn", "Show only warnings and errors.");
-        printf("  %-16s  %s\n", "--error", "Show only errors.");
-        printf("  %-16s  %s\n", "-b, --batch", "Batch output.");
-        printf("  %-16s  %s\n", "-q, --quiet", "Suppress all output.");
-        printf("  %-16s  %s\n", "--version", "Show version number.");
-        printf("  %-16s  %s\n", "--devices", "List computation devices.");
-        printf("  %-16s  %s\n", "--profile", "Enable OpenCL profiling.");
-        printf("  %-16s  %s\n", "--batch-header", "Batch output header.");
         for(size_t i = 0, n = noptions(); i < n; ++i)
         {
             char opt[50];
             char def[100];
             sprintf(opt, "--%.20s=<%s>", option_name(i), option_type(i));
-            printf("  %-16s  %s", opt, option_help(i));
+            printf("  %-20s  %s", opt, option_help(i));
             if(!option_required(i))
             {
                 option_default_value(def, sizeof(def), i);

--- a/src/input/options.c
+++ b/src/input/options.c
@@ -26,7 +26,6 @@ struct option
         int default_int;
         double default_real;
         const char* default_path;
-        const char* default_device;
         struct gain* default_gain;
     } default_value;
     size_t offset;
@@ -58,7 +57,6 @@ OPTION_TYPE(bool)
 OPTION_TYPE(int)
 OPTION_TYPE(real)
 OPTION_TYPE(path)
-OPTION_TYPE(device)
 OPTION_TYPE(gain)
 
 // list of known options
@@ -66,7 +64,7 @@ struct option OPTIONS[] = {
     {
         "device",
         "Select computation device",
-        OPTION_OPTIONAL(device, "auto"),
+        OPTION_OPTIONAL(string, "auto"),
         OPTION_FIELD(device)
     },
     {
@@ -458,37 +456,6 @@ int option_write_path(char* out, const void* in, size_t n)
 }
 
 void option_free_path(void* p)
-{
-    char** str = p;
-    free(*str);
-}
-
-int option_read_device(void* out, const char* in)
-{
-    int r;
-    char* str;
-    char tag;
-    unsigned int index;
-    
-    // read string
-    r = option_read_string(out, in);
-    if(r != 0)
-        return r;
-    str = *(char**)out;
-    
-    // check syntax
-    if(sscanf(str, "%[gc]pu%u", &tag, &index) != 2)
-        return 1;
-    
-    return 0;
-}
-
-int option_write_device(char* out, const void* in, size_t n)
-{
-    return option_write_string(out, in, n);
-}
-
-void option_free_device(void* p)
 {
     char** str = p;
     free(*str);

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -167,15 +167,17 @@ int main(int argc, char* argv[])
         char platform_name[128];
         cl_uint compute_units;
         
+        printf("\n");
+        
         // go through devices and show info
         for(lensed_device* d = get_lensed_devices(); d->device_id; ++d)
         {
             // show device
-            printf("%s: ", d->name);
+            printf("device: %s\n", d->name);
             
             // query device name
             err = clGetDeviceInfo(d->device_id, CL_DEVICE_NAME, sizeof(device_name), device_name, NULL);
-            printf("%s\n", err == CL_SUCCESS ? device_name : "(unknown)");
+            printf("  name:     %s\n", err == CL_SUCCESS ? device_name : "(unknown)");
             
             // query device vendor
             err = clGetDeviceInfo(d->device_id, CL_DEVICE_VENDOR, sizeof(device_vendor), device_vendor, NULL);


### PR DESCRIPTION
A number of minor tweaks to the output of `--help` and `--devices`.

-   Separate list of flags and options in `--help`.
-   More space for options in `--help`.
-   Clearly marked device name in `--devices`.