### PR TITLE
use array instead of vector for param bounds

### DIFF
--- a/kernel/object.cl
+++ b/kernel/object.cl
@@ -21,7 +21,7 @@ enum
 // structure that holds parameter definition
 struct param
 {
-    char   name[16];
-    int    type;
-    float2 bounds;
+    char  name[16];
+    int   type;
+    float bounds[2] __attribute__ ((aligned (4)));
 };

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -56,7 +56,7 @@ static const char PARSKERN[] =
     "    size_t i = get_global_id(0);\n"
     "    names[i] = vload16(0, parlst_<name>[i].name);\n"
     "    types[i] = parlst_<name>[i].type;\n"
-    "    bounds[i] = parlst_<name>[i].bounds;\n"
+    "    bounds[i] = vload2(0, parlst_<name>[i].bounds);\n"
     "}\n"
 ;
 


### PR DESCRIPTION
This PR fixes a compiler bug in old versions of the Nvidia drivers where static arrays cannot be initialised with vectors. The fix changes the `float2` vector to a `float[2]` array, which makes no difference at all for us.