### PR TITLE
fix OpenCL queue properties no longer set after merge

### DIFF
--- a/src/lensed.c
+++ b/src/lensed.c
@@ -520,7 +520,7 @@ int main(int argc, char* argv[])
         if(inp->opts->profile)
             queue_properties |= CL_QUEUE_PROFILING_ENABLE;
         
-        lensed->queue = clCreateCommandQueue(lcl->context, lcl->device_id, 0, &err);
+        lensed->queue = clCreateCommandQueue(lcl->context, lcl->device_id, queue_properties, &err);
         if(!lensed->queue || err != CL_SUCCESS)
             error("failed to create command queue");
         


### PR DESCRIPTION
Error introduced in db7e4b8.