### PR TITLE
use cl_float instead of cl_char for object memory

### DIFF
--- a/kernel/lensed.cl
+++ b/kernel/lensed.cl
@@ -6,7 +6,7 @@
 #endif
 
 // compute image
-kernel void render(constant char* data, float4 pcs,
+kernel void render(constant float* data, float4 pcs,
                    constant float2* qq, constant float2* ww,
                    global float* value, global float* error)
 {

--- a/kernel/object.cl
+++ b/kernel/object.cl
@@ -19,9 +19,9 @@ enum
 };
 
 // structure that holds parameter definition
-struct param
+struct __attribute__ ((aligned (4))) param
 {
     char  name[16];
     int   type;
-    float bounds[2] __attribute__ ((aligned (4)));
+    float bounds[2];
 };

--- a/src/input/objects.c
+++ b/src/input/objects.c
@@ -132,6 +132,9 @@ void add_object(input* inp, const char* id, const char* name)
     if(err != CL_SUCCESS)
         error("object %s: failed to get metadata", id);
     
+    // convert size in sizeof(cl_char) to size in sizeof(cl_float), rounding up
+    meta_size = ((meta_size*sizeof(cl_char))/sizeof(cl_float)) + ((meta_size*sizeof(cl_char))%sizeof(cl_float) ? 1 : 0);
+    
     // set metadata for object
     obj->type  = meta_type;
     obj->size  = meta_size;

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -62,7 +62,7 @@ static const char PARSKERN[] =
 
 // kernel to compute images
 static const char COMPHEAD[] =
-    "static float compute(constant char* data, float2 x)\n"
+    "static float compute(constant float* data, float2 x)\n"
     "{\n"
     "    // ray position\n"
     "    float2 y = x;\n"
@@ -111,7 +111,7 @@ static const char COMPFOOT[] =
 
 // kernel to set parameters
 static const char SETPHEAD[] =
-    "kernel void set_params(global char* data, constant float* params)\n"
+    "kernel void set_params(global float* data, constant float* params)\n"
     "{\n"
 ;
 static const char SETPLEFT[] = "    set_%s((global void*)(data + %zu)";
@@ -125,7 +125,7 @@ static const char SETPFOOT[] =
 static const char OBJHEAD[] =
     "#define type constant int type_%s\n"
     "#define params constant struct param parlst_%s[] = \n"
-    "#define data struct data_%s\n"
+    "#define data struct __attribute__ ((aligned (4))) data_%s\n"
     "#define deflection deflection_%s\n"
     "#define brightness brightness_%s\n"
     "#define foreground foreground_%s\n"

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -657,7 +657,7 @@ int main(int argc, char* argv[])
     
     // create buffer that contains object data
     {
-        // collect total size of object data
+        // collect total size of object data, in units of sizeof(cl_float)
         size_t object_size = 0;
         for(size_t i = 0; i < inp->nobjs; ++i)
             object_size += inp->objs[i].size;
@@ -665,7 +665,7 @@ int main(int argc, char* argv[])
         verbose("  create object buffer");
         
         // allocate buffer for object data
-        object_mem = clCreateBuffer(lcl->context, CL_MEM_READ_WRITE, object_size, NULL, &err);
+        object_mem = clCreateBuffer(lcl->context, CL_MEM_READ_WRITE, object_size*sizeof(cl_float), NULL, &err);
         if(err != CL_SUCCESS)
             error("failed to create object buffer");
     }


### PR DESCRIPTION
With this PR, the memory for objects is allocated and addressed in blocks of `cl_float` instead of individual `ch_char` bytes. Furthermore, the default alignment of the `data` structure was changed to 4 bytes, to accommodate the OpenCL restriction on byte-addressable storage.