### PR TITLE
show progress in MultiNest feedback

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,7 +79,7 @@ Option     | Type           | Description                            | Default
 `shf`      | `real`         | Shrinking factor.                      | `0.8`
 `maxmodes` | `int`          | Maximum number of expected modes.      | `100`
 `feedback` | `bool`         | Show feedback from MultiNest.          | `false`
-`updint`   | `int`          | Update interval for output.            | `1000`
+`updint`   | `int`          | Update interval for output.            | `100`
 `seed`     | `int`          | Random number seed for sampling.       | `-1`
 `resume`   | `bool`         | Resume from last checkpoint.           | `false`
 `maxiter`  | `int`          | Maximum number of iterations.          | `0`

--- a/src/input/options.c
+++ b/src/input/options.c
@@ -172,7 +172,7 @@ struct option OPTIONS[] = {
     {
         "updint",
         "Update interval for output",
-        OPTION_OPTIONAL(int, 1000),
+        OPTION_OPTIONAL(int, 100),
         OPTION_FIELD(updint)
     },
     {

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -436,6 +436,9 @@ int main(int argc, char* argv[])
         lensed->fits = NULL;
     }
     
+    // MultiNest tolerance
+    lensed->tol = inp->opts->tol;
+    
     // arrays for parameters
     lensed->mean  = calloc(lensed->npars, sizeof(double));
     lensed->sigma = calloc(lensed->npars, sizeof(double));
@@ -1051,6 +1054,11 @@ int main(int argc, char* argv[])
     // take end time
     end = time(0);
     
+    // show duration
+    dur = difftime(end, start);
+    info("  done in %02d:%02d:%02d", (int)(dur/3600), (int)(fmod(dur, 3600)/60), (int)fmod(dur, 60));
+    info("  ");
+    
     
     /***********
      * results *
@@ -1058,10 +1066,6 @@ int main(int argc, char* argv[])
     
     // compute chi^2/dof
     chi2_dof = -2*lensed->max_loglike / (lensed->size - masked - lensed->npars);
-    
-    // duration
-    dur = difftime(end, start);
-    info("done in %02d:%02d:%02d", (int)(dur/3600), (int)(fmod(dur, 3600)/60), (int)fmod(dur, 60));
     
     // summary statistics
     info("summary");

--- a/src/lensed.h
+++ b/src/lensed.h
@@ -13,6 +13,9 @@ struct lensed
     size_t npars;
     param** pars;
     
+    // MultiNest tolerance
+    double tol;
+    
     // results
     const char* fits;
     double logev;

--- a/src/nested.c
+++ b/src/nested.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <float.h>
 #include <math.h>
+#include <time.h>
 
 #include "opencl.h"
 #include "input.h"
@@ -138,6 +139,8 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
     
     cl_float* output[4] = {0};
     
+    double progress;
+    
     // copy parameters to results
     for(size_t i = 0; i < lensed->npars; ++i)
         lensed->mean[i] = constraints[0][MEAN*lensed->npars+i];
@@ -228,5 +231,29 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
         // free arrays
         free(residuals);
         free(relerr);
+    }
+    
+    // calculate progress
+    progress = fmax(0, fmin(1, 1.0*nsamples[0]/nlive[0]/(maxloglike[0] - logz[0] - log(lensed->tol))));
+    
+    // status output
+    if(LOG_LEVEL <= LOG_INFO)
+    {
+        char ts[10];
+        time_t t = time(NULL);
+        
+        int i = 0;
+        int n = round(20*progress) + 0.5;
+        int p = round(100*progress) + 0.5;
+        
+        strftime(ts, 10, "%H:%M:%S", localtime(&t));
+        
+        fprintf(stdout, "  %s [", ts);
+        for(; i < n; ++i)
+            fputc('#', stdout);
+        for(; i < 20; ++i)
+            fputc(' ', stdout);
+        fprintf(stdout, "] %d%% | S: %d\r", p, nsamples[0]);
+        fflush(stdout);
     }
 }


### PR DESCRIPTION
In light of #78, I have tried to make the posterior sampling phase of Lensed more informative.

To get a better idea of how far along the algorithm is, I approximate the `tol` stopping criterion of MultiNest and calculate after how many samples it is going to be fulfilled, assuming no higher maximum likelihood will be found.

And to check whether or not the algorithm hit a roadblock, the time and number of samples of the last update are displayed.

This is what the output looks like:

```
find posterior
  
 *****************************************************
 MultiNest v3.9
 Copyright Farhan Feroz & Mike Hobson
 Release Oct 2014

 no. of live points =  100
 dimensionality =   12
 running in constant efficiency mode
 *****************************************************
  15:32:41 [#############       ] 65% | S: 1100
```
