### PR TITLE
show maxloglike in progress

### DIFF
--- a/src/nested.c
+++ b/src/nested.c
@@ -3,7 +3,6 @@
 #include <string.h>
 #include <float.h>
 #include <math.h>
-#include <time.h>
 
 #include "opencl.h"
 #include "input.h"
@@ -139,8 +138,6 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
     
     cl_float* output[4] = {0};
     
-    double progress;
-    
     // copy parameters to results
     for(size_t i = 0; i < lensed->npars; ++i)
         lensed->mean[i] = constraints[0][MEAN*lensed->npars+i];
@@ -233,27 +230,22 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
         free(relerr);
     }
     
-    // calculate progress
-    progress = fmax(0, fmin(1, 1.0*nsamples[0]/nlive[0]/(maxloglike[0] - logz[0] - log(lensed->tol))));
-    
     // status output
     if(LOG_LEVEL <= LOG_INFO)
     {
-        char ts[10];
-        time_t t = time(NULL);
+        // calculate progress
+        double progress = fmax(0, fmin(1, 1.0*nsamples[0]/nlive[0]/(maxloglike[0] - logz[0] - log(lensed->tol))));
         
         int i = 0;
-        int n = round(20*progress) + 0.5;
-        int p = round(100*progress) + 0.5;
+        int n = floor(20*progress) + 0.5;
+        int p = fmin(99, floor(100*progress)) + 0.5;
         
-        strftime(ts, 10, "%H:%M:%S", localtime(&t));
-        
-        fprintf(stdout, "  %s [", ts);
+        fprintf(stdout, "  [");
         for(; i < n; ++i)
             fputc('#', stdout);
         for(; i < 20; ++i)
             fputc(' ', stdout);
-        fprintf(stdout, "] %d%% | S: %d\r", p, nsamples[0]);
+        fprintf(stdout, "] %2d%% | L: %+10.3e | S: %d\r", p, maxloglike[0], nsamples[0]);
         fflush(stdout);
     }
 }


### PR DESCRIPTION
Replaces output of time by output of maximum log-likelihood in progress, so that it's clear what's going on when progress decreases.