### PR TITLE
pseudo-priors and derived parameters

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -244,7 +244,7 @@ input* read_input(int argc, char* argv[])
         for(size_t i = 0; i < inp->nobjs; ++i)
             for(size_t j = 0; j < inp->objs[i].npars; ++j)
                 if(!inp->objs[i].pars[j].pri)
-                    error("missing prior: %s.%s (check [priors] section)", inp->objs[i].id, inp->objs[i].pars[j].name);
+                    error("missing prior: %s (check [priors] section)", inp->objs[i].pars[j].id);
     }
     
     // everything is fine
@@ -275,17 +275,21 @@ void print_input(const input* inp)
             for(size_t j = 0; j < inp->objs[i].npars; ++j, ++p)
             {
                 const char* label;
-                char buf[100] = {0};
-                char tag[100] = {0};
+                char rel;
+                char buf[256] = {0};
+                char tag[256] = {0};
                 
                 // set label, or id if no label set
                 label = inp->objs[i].pars[j].label ? inp->objs[i].pars[j].label : inp->objs[i].pars[j].id;
                 
+                // relation between variable and prior
+                rel = inp->objs[i].pars[j].derived ? '=' : '~';
+                
                 // pretty-print prior
-                prior_print(inp->objs[i].pars[j].pri, buf, 99);
+                prior_print(inp->objs[i].pars[j].pri, buf, 255);
                 
                 // collect tags
-                snprintf(tag, 100, " [%s%s%s%s%s%s%s%s%s",
+                snprintf(tag, 255, " [%s%s%s%s%s%s%s%s%s",
                     inp->objs[i].pars[j].type == PAR_POSITION_X ?
                         "position x, " : "",
                     inp->objs[i].pars[j].type == PAR_POSITION_Y ?
@@ -321,7 +325,7 @@ void print_input(const input* inp)
                 }
                 
                 // output line for parameter
-                verbose("  %zu: %s ~ %s%s", p, label, buf, tag);
+                verbose("  %zu: %s %c %s%s", p, label, rel, buf, tag);
             }
         }
     }

--- a/src/input.c
+++ b/src/input.c
@@ -282,7 +282,7 @@ void print_input(const input* inp)
                 label = inp->objs[i].pars[j].label ? inp->objs[i].pars[j].label : inp->objs[i].pars[j].id;
                 
                 // pretty-print prior
-                print_prior(inp->objs[i].pars[j].pri, buf, 99);
+                prior_print(inp->objs[i].pars[j].pri, buf, 99);
                 
                 // collect tags
                 snprintf(tag, 100, " [%s%s%s%s%s%s%s%s%s",

--- a/src/input.h
+++ b/src/input.h
@@ -90,6 +90,9 @@ typedef struct
     // flag for image plane priors
     int ipp;
     
+    // flag for derived parameters
+    int derived;
+    
     // label, used for output
     const char* label;
 } param;

--- a/src/input/objects.c
+++ b/src/input/objects.c
@@ -296,7 +296,7 @@ void free_param(param* par)
     free((char*)par->name);
     free((char*)par->id);
     free((char*)par->label);
-    free_prior(par->pri);
+    prior_free(par->pri);
 }
 
 void set_param_label(param* par, const char* label)
@@ -315,7 +315,7 @@ void set_param_prior(param* par, const char* str)
     size_t len;
     
     // free existing prior
-    free_prior(par->pri);
+    prior_free(par->pri);
     
     // parse possible keywords
     while(1)
@@ -337,5 +337,5 @@ void set_param_prior(param* par, const char* str)
     }
     
     // parse prior
-    par->pri = *str ? read_prior(str) : NULL;
+    par->pri = *str ? prior_read(str) : NULL;
 }

--- a/src/lensed.h
+++ b/src/lensed.h
@@ -11,7 +11,9 @@ struct lensed
     
     // parameter space
     size_t npars;
+    size_t ndims;
     param** pars;
+    size_t* pmap;
     
     // MultiNest tolerance
     double tol;

--- a/src/nested.c
+++ b/src/nested.c
@@ -39,12 +39,23 @@ void loglike(double cube[], int* ndim, int* npar, double* lnew, void* lensed_)
     }
     
     // transform from unit cube to physical
-    for(size_t i = 0; i < lensed->npars; ++i)
+    for(size_t i = 0; i < *npar; ++i)
     {
+        // input parameter value; fixed to 0.5 for pseudo-priors
+        double unit = i < *ndim ? cube[i] : 0.5;
+        
+        // physical parameter value
         double phys;
+        
+        // get parameter using map
+        param* par = lensed->pars[lensed->pmap[i]];
+        
+        // draw parameter until it is within the bounds
         do
-            phys = prior_apply(lensed->pars[i]->pri, cube[i]);
-        while(lensed->pars[i]->bounded && (phys < lensed->pars[i]->lower || phys > lensed->pars[i]->upper));
+            phys = prior_apply(par->pri, unit);
+        while(par->bounded && (phys < par->lower || phys > par->upper));
+        
+        // store physical parameter
         cube[i] = phys;
     }
     
@@ -54,9 +65,9 @@ void loglike(double cube[], int* ndim, int* npar, double* lnew, void* lensed_)
     // map parameter space on device
     cl_float* params = clEnqueueMapBuffer(lensed->queue, lensed->params, CL_TRUE, CL_MAP_WRITE, 0, lensed->npars*sizeof(cl_float), 0, NULL, map_params_ev, &err);
     
-    // copy parameters to device
+    // copy parameters to device using map
     for(size_t i = 0; i < lensed->npars; ++i)
-        params[i] = cube[i];
+        params[lensed->pmap[i]] = cube[i];
     
     // done with parameter space
     clEnqueueUnmapMemObject(lensed->queue, lensed->params, params, 0, NULL, unmap_params_ev);
@@ -139,13 +150,16 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
     
     // copy parameters to results
     for(size_t i = 0; i < lensed->npars; ++i)
-        lensed->mean[i] = constraints[0][MEAN*lensed->npars+i];
-    for(size_t i = 0; i < lensed->npars; ++i)
-        lensed->sigma[i] = constraints[0][SIGMA*lensed->npars+i];
-    for(size_t i = 0; i < lensed->npars; ++i)
-        lensed->ml[i] = constraints[0][ML*lensed->npars+i];
-    for(size_t i = 0; i < lensed->npars; ++i)
-        lensed->map[i] = constraints[0][MAP*lensed->npars+i];
+    {
+        // get parameter index from map
+        size_t p = lensed->pmap[i];
+        
+        // store values
+        lensed->mean[p]     = constraints[0][MEAN*lensed->npars+i];
+        lensed->sigma[p]    = constraints[0][SIGMA*lensed->npars+i];
+        lensed->ml[p]       = constraints[0][ML*lensed->npars+i];
+        lensed->map[p]      = constraints[0][MAP*lensed->npars+i];
+    }
     
     // copy summary statistics
     lensed->logev = *logz;
@@ -159,9 +173,9 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
         // map parameter space on device
         cl_float* params = clEnqueueMapBuffer(lensed->queue, lensed->params, CL_TRUE, CL_MAP_WRITE, 0, lensed->npars*sizeof(cl_float), 0, NULL, NULL, &err);
         
-        // copy ML parameters to device
+        // copy ML parameters to device using map
         for(size_t i = 0; i < lensed->npars; ++i)
-            params[i] = constraints[0][ML*lensed->npars+i];
+            params[lensed->pmap[i]] = constraints[0][ML*lensed->npars+i];
         
         // done with parameter space
         clEnqueueUnmapMemObject(lensed->queue, lensed->params, params, 0, NULL, NULL);

--- a/src/nested.c
+++ b/src/nested.c
@@ -43,9 +43,8 @@ void loglike(double cube[], int* ndim, int* npar, double* lnew, void* lensed_)
     {
         double phys;
         do
-            phys = apply_prior(lensed->pars[i]->pri, cube[i]);
-        while(lensed->pars[i]->bounded &&
-              (phys < lensed->pars[i]->lower || phys > lensed->pars[i]->upper));
+            phys = prior_apply(lensed->pars[i]->pri, cube[i]);
+        while(lensed->pars[i]->bounded && (phys < lensed->pars[i]->lower || phys > lensed->pars[i]->upper));
         cube[i] = phys;
     }
     

--- a/src/prior.h
+++ b/src/prior.h
@@ -1,19 +1,22 @@
 #pragma once
 
 // read a prior from string
-prior* read_prior(const char* str);
+prior* prior_read(const char* str);
 
 // free all memory allocated by prior
-void free_prior(prior* pri);
+void prior_free(prior* pri);
 
 // output prior to string
-void print_prior(const prior* pri, char* buf, size_t n);
+void prior_print(const prior* pri, char* buf, size_t n);
 
 // apply prior to unit variate
-double apply_prior(const prior* pri, double u);
+double prior_apply(const prior* pri, double u);
 
 // get lower bound for prior
 double prior_lower(const prior* pri);
 
 // get upper bound for prior
 double prior_upper(const prior* pri);
+
+// flag whether this is a pseudo-prior (= calculated instead of drawn)
+int prior_pseudo(const prior* pri);

--- a/src/prior/delta.c
+++ b/src/prior/delta.c
@@ -5,7 +5,7 @@
 #include "../parse.h"
 #include "../log.h"
 
-void* read_prior_delta(size_t nargs, const char* argv[])
+void* prior_read_delta(size_t nargs, const char* argv[])
 {
     double* x;
     
@@ -22,29 +22,27 @@ void* read_prior_delta(size_t nargs, const char* argv[])
     return x;
 }
 
-void free_prior_delta(void* data)
+void prior_free_delta(void* data)
 {
     free(data);
 }
 
-void print_prior_delta(const void* data, char* buf, size_t n)
+void prior_print_delta(const void* data, char* buf, size_t n)
 {
     const double* x = data;
     
     write_real(buf, *x, n);
 }
 
-double prior_delta(const void* data, double u)
+double prior_apply_delta(const void* data, double u)
 {
     return *(double*)data;
 }
-
 
 double prior_lower_delta(const void* data)
 {
     return *(double*)data;
 }
-
 
 double prior_upper_delta(const void* data)
 {

--- a/src/prior/delta.h
+++ b/src/prior/delta.h
@@ -1,8 +1,8 @@
 #pragma once
 
-void* read_prior_delta(size_t nargs, const char* args[]);
-void free_prior_delta(void* data);
-void print_prior_delta(const void* data, char* buf, size_t n);
-double prior_delta(const void* data, double u);
-double prior_lower_delta(const void* data);
-double prior_upper_delta(const void* data);
+void*   prior_read_delta(size_t nargs, const char* args[]);
+void    prior_free_delta(void* data);
+void    prior_print_delta(const void* data, char* buf, size_t n);
+double  prior_apply_delta(const void* data, double u);
+double  prior_lower_delta(const void* data);
+double  prior_upper_delta(const void* data);

--- a/src/prior/norm.c
+++ b/src/prior/norm.c
@@ -20,7 +20,7 @@ struct norm
     double s;
 };
 
-void* read_prior_norm(size_t nargs, const char* argv[])
+void* prior_read_norm(size_t nargs, const char* argv[])
 {
     struct norm* n;
     
@@ -47,12 +47,12 @@ void* read_prior_norm(size_t nargs, const char* argv[])
     return n;
 }
 
-void free_prior_norm(void* data)
+void prior_free_norm(void* data)
 {
     free(data);
 }
 
-void print_prior_norm(const void* data, char* buf, size_t n)
+void prior_print_norm(const void* data, char* buf, size_t n)
 {
     const struct norm* norm = data;
     
@@ -74,7 +74,7 @@ void print_prior_norm(const void* data, char* buf, size_t n)
     strcat(buf, ")");
 }
 
-double prior_norm(const void* data, double u)
+double prior_apply_norm(const void* data, double u)
 {
     const struct norm* norm = data;
     

--- a/src/prior/norm.h
+++ b/src/prior/norm.h
@@ -1,8 +1,8 @@
 #pragma once
 
-void* read_prior_norm(size_t nargs, const char* args[]);
-void free_prior_norm(void* data);
-void print_prior_norm(const void* data, char* buf, size_t n);
-double prior_norm(const void* data, double u);
-double prior_lower_norm(const void* data);
-double prior_upper_norm(const void* data);
+void*   prior_read_norm(size_t nargs, const char* args[]);
+void    prior_free_norm(void* data);
+void    prior_print_norm(const void* data, char* buf, size_t n);
+double  prior_apply_norm(const void* data, double u);
+double  prior_lower_norm(const void* data);
+double  prior_upper_norm(const void* data);

--- a/src/prior/unif.c
+++ b/src/prior/unif.c
@@ -11,7 +11,7 @@ struct uniform
     double b;
 };
 
-void* read_prior_unif(size_t nargs, const char* argv[])
+void* prior_read_unif(size_t nargs, const char* argv[])
 {
     struct uniform* unif;
     
@@ -38,12 +38,12 @@ void* read_prior_unif(size_t nargs, const char* argv[])
     return unif;
 }
 
-void free_prior_unif(void* data)
+void prior_free_unif(void* data)
 {
     free(data);
 }
 
-void print_prior_unif(const void* data, char* buf, size_t n)
+void prior_print_unif(const void* data, char* buf, size_t n)
 {
     const struct uniform* unif = data;
     
@@ -65,7 +65,7 @@ void print_prior_unif(const void* data, char* buf, size_t n)
     strcat(buf, ")");
 }
 
-double prior_unif(const void* data, double u)
+double prior_apply_unif(const void* data, double u)
 {
     const struct uniform* unif = data;
     

--- a/src/prior/unif.h
+++ b/src/prior/unif.h
@@ -1,8 +1,8 @@
 #pragma once
 
-void* read_prior_unif(size_t nargs, const char* args[]);
-void free_prior_unif(void* data);
-void print_prior_unif(const void* data, char* buf, size_t n);
-double prior_unif(const void* data, double u);
-double prior_lower_unif(const void* data);
-double prior_upper_unif(const void* data);
+void*   prior_read_unif(size_t nargs, const char* args[]);
+void    prior_free_unif(void* data);
+void    prior_print_unif(const void* data, char* buf, size_t n);
+double  prior_apply_unif(const void* data, double u);
+double  prior_lower_unif(const void* data);
+double  prior_upper_unif(const void* data);


### PR DESCRIPTION
This PR allows priors to be declared `pseudo-priors`, which return a value not using some random distribution but a given function. For now, only the delta function prior is a pseudo-prior.

Additionally, parameters with a pseudo-prior are now treated as derived parameters for MultiNest (cf. #27), reducing the dimensionality of the parameter space that has to be explored.

There is a caveat: MultiNest expects the derived parameters to be at the end of the parameter list, and this is reflected in its generated files. To make sure the parameter order is correct, check out the generated `.paramnames` file.