### PR TITLE
suppress file output from Fortran in quiet or batch mode

### DIFF
--- a/src/lensed.c
+++ b/src/lensed.c
@@ -1318,5 +1318,9 @@ int main(int argc, char* argv[])
     // free lensed struct
     free(lensed);
     
+    // there might be unflushed output from Fortran on stdout
+    if(LOG_LEVEL == LOG_QUIET || LOG_LEVEL == LOG_BATCH)
+        mute();
+    
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR fixes a bug that snuck in after being originally handled in #49. In batch output mode, MultiNest is muted. However, when writing to a file (`lensed --batch > results.ini`), Fortran uses buffering for stdout, so that MultiNest's messages are written on program termination, when output is no longer muted. The workaround is to mute output again when in quiet or batch mode right before terminating.