### PR TITLE
default parameter values

### DIFF
--- a/kernel/object.cl
+++ b/kernel/object.cl
@@ -18,10 +18,16 @@ enum
     POS_ANGLE
 };
 
+// parameter bounds
+#define UNBOUNDED {0, 0}
+#define POS_BOUND {0, INFINITY}
+#define NEG_BOUND {-INFINITY, 0}
+
 // structure that holds parameter definition
 struct __attribute__ ((aligned (4))) param
 {
     char  name[16];
     int   type;
     float bounds[2];
+    float defval;
 };

--- a/src/input.c
+++ b/src/input.c
@@ -270,44 +270,42 @@ void print_input(const input* inp)
             verbose("  %s = %s", inp->objs[i].id, inp->objs[i].name);
         
         verbose("parameters");
-        for(size_t i = 0, p = 1; i < inp->nobjs; ++i)
+        for(size_t i = 0, p = 0; i < inp->nobjs; ++i)
         {
-            for(size_t j = 0; j < inp->objs[i].npars; ++j, ++p)
+            for(size_t j = 0; j < inp->objs[i].npars; ++j)
             {
                 const char* label;
                 char rel;
                 char buf[256] = {0};
                 char tag[256] = {0};
                 
+                // current parameter
+                const param* par = &inp->objs[i].pars[j];
+                
+                // skip default values
+                if(par->defval)
+                    continue;
+                
                 // set label, or id if no label set
-                label = inp->objs[i].pars[j].label ? inp->objs[i].pars[j].label : inp->objs[i].pars[j].id;
+                label = par->label ? par->label : par->id;
                 
                 // relation between variable and prior
-                rel = inp->objs[i].pars[j].derived ? '=' : '~';
+                rel = par->derived ? '=' : '~';
                 
                 // pretty-print prior
-                prior_print(inp->objs[i].pars[j].pri, buf, 255);
+                prior_print(par->pri, buf, 255);
                 
                 // collect tags
                 snprintf(tag, 255, " [%s%s%s%s%s%s%s%s%s",
-                    inp->objs[i].pars[j].type == PAR_POSITION_X ?
-                        "position x, " : "",
-                    inp->objs[i].pars[j].type == PAR_POSITION_Y ?
-                        "position y, " : "",
-                    inp->objs[i].pars[j].type == PAR_RADIUS ?
-                        "radius, " : "",
-                    inp->objs[i].pars[j].type == PAR_MAGNITUDE ?
-                        "magnitude, " : "",
-                    inp->objs[i].pars[j].type == PAR_AXIS_RATIO ?
-                        "axis ratio, " : "",
-                    inp->objs[i].pars[j].type == PAR_POS_ANGLE ?
-                        "pos. angle, " : "",
-                    inp->objs[i].pars[j].bounded ?
-                        "bounded, " : "",
-                    inp->objs[i].pars[j].wrap ?
-                        "wrap, " : "",
-                    inp->objs[i].pars[j].ipp ?
-                        "IPP, " : ""
+                    par->type == PAR_POSITION_X ? "position x, " : "",
+                    par->type == PAR_POSITION_Y ? "position y, " : "",
+                    par->type == PAR_RADIUS     ? "radius, "     : "",
+                    par->type == PAR_MAGNITUDE  ? "magnitude, "  : "",
+                    par->type == PAR_AXIS_RATIO ? "axis ratio, " : "",
+                    par->type == PAR_POS_ANGLE  ? "pos. angle, " : "",
+                    par->bounded                ? "bounded, "    : "",
+                    par->wrap                   ? "wrap, "       : "",
+                    par->ipp                    ? "IPP, "        : ""
                 );
                 
                 // check if tags were set
@@ -325,7 +323,7 @@ void print_input(const input* inp)
                 }
                 
                 // output line for parameter
-                verbose("  %zu: %s %c %s%s", p, label, rel, buf, tag);
+                verbose("  %zu: %s %c %s%s", ++p, label, rel, buf, tag);
             }
         }
     }

--- a/src/input.h
+++ b/src/input.h
@@ -93,6 +93,9 @@ typedef struct
     // flag for derived parameters
     int derived;
     
+    // flag for default value
+    int defval;
+    
     // label, used for output
     const char* label;
 } param;

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -51,12 +51,13 @@ static const char METAKERN[] =
 // kernel to get parameters for object
 static const char PARSKERN[] = 
     "kernel void params_<name>(global char16* names, global int* types,\n"
-    "                          global float2* bounds)\n"
+    "                          global float2* bounds, global float* defvals)\n"
     "{\n"
     "    size_t i = get_global_id(0);\n"
     "    names[i] = vload16(0, parlst_<name>[i].name);\n"
     "    types[i] = parlst_<name>[i].type;\n"
     "    bounds[i] = vload2(0, parlst_<name>[i].bounds);\n"
+    "    defvals[i] = parlst_<name>[i].defval;\n"
     "}\n"
 ;
 

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -715,8 +715,6 @@ int main(int argc, char* argv[])
         const char* build_flags[] = {
             "-cl-denorms-are-zero",
             "-cl-strict-aliasing",
-            "-cl-mad-enable",
-            "-cl-no-signed-zeros",
             "-cl-fast-relaxed-math",
             NULL
         };
@@ -1233,9 +1231,10 @@ int main(int argc, char* argv[])
          "parameter", "mean", "sigma", "ML", "MAP");
     info("  ------------------------------------------------------------");
     for(size_t i = 0; i < lensed->npars; ++i)
-        info("  %-12s  %10.4f  %10.4f  %10.4f  %10.4f",
-             lensed->pars[i]->label ? lensed->pars[i]->label : lensed->pars[i]->id,
-             lensed->mean[i], lensed->sigma[i], lensed->ml[i], lensed->map[i]);
+        if(!lensed->pars[i]->defval)
+            info("  %-12s  %10.4f  %10.4f  %10.4f  %10.4f",
+                lensed->pars[i]->label ? lensed->pars[i]->label : lensed->pars[i]->id,
+                lensed->mean[i], lensed->sigma[i], lensed->ml[i], lensed->map[i]);
     info("  ");
     
     // profiling results
@@ -1325,13 +1324,17 @@ int main(int argc, char* argv[])
         
         // write parameter results
         for(size_t i = 0; i < lensed->npars; ++i)
-            printf("%-10.4f  ", lensed->mean[i]);
+            if(!lensed->pars[i]->defval)
+                printf("%-10.4f  ", lensed->mean[i]);
         for(size_t i = 0; i < lensed->npars; ++i)
-            printf("%-10.4f  ", lensed->sigma[i]);
+            if(!lensed->pars[i]->defval)
+                printf("%-10.4f  ", lensed->sigma[i]);
         for(size_t i = 0; i < lensed->npars; ++i)
-            printf("%-10.4f  ", lensed->ml[i]);
+            if(!lensed->pars[i]->defval)
+                printf("%-10.4f  ", lensed->ml[i]);
         for(size_t i = 0; i < lensed->npars; ++i)
-            printf("%-10.4f  ", lensed->map[i]);
+            if(!lensed->pars[i]->defval)
+                printf("%-10.4f  ", lensed->map[i]);
         
         // output is done
         printf("\n");

--- a/src/prior.c
+++ b/src/prior.c
@@ -161,6 +161,28 @@ prior* prior_read(const char* str)
     return pri;
 }
 
+prior* prior_default(double value)
+{
+    // create prior
+    prior* pri = malloc(sizeof(prior));
+    if(!pri)
+        errori(NULL);
+    
+    // set up prior functions
+    pri->free       = prior_free_delta;
+    pri->print      = prior_print_delta;
+    pri->apply      = prior_apply_delta;
+    pri->lower      = prior_lower_delta;
+    pri->upper      = prior_upper_delta;
+    pri->pseudo     = 1;
+    
+    // make prior data
+    pri->data       = prior_make_delta(value);
+    
+    // prior is ready
+    return pri;
+}
+
 void prior_free(prior* pri)
 {
     if(pri)

--- a/src/prior.h
+++ b/src/prior.h
@@ -3,6 +3,9 @@
 // read a prior from string
 prior* prior_read(const char* str);
 
+// default prior with value
+prior* prior_default(double value);
+
 // free all memory allocated by prior
 void prior_free(prior* pri);
 

--- a/src/prior/delta.c
+++ b/src/prior/delta.c
@@ -5,6 +5,19 @@
 #include "../parse.h"
 #include "../log.h"
 
+void* prior_make_delta(double value)
+{
+    double* x;
+    
+    x = malloc(sizeof(double));
+    if(!x)
+        errori(NULL);
+    
+    *x = value;
+    
+    return x;
+}
+
 void* prior_read_delta(size_t nargs, const char* argv[])
 {
     double* x;

--- a/src/prior/delta.h
+++ b/src/prior/delta.h
@@ -1,5 +1,6 @@
 #pragma once
 
+void*   prior_make_delta(double value);
 void*   prior_read_delta(size_t nargs, const char* args[]);
 void    prior_free_delta(void* data);
 void    prior_print_delta(const void* data, char* buf, size_t n);


### PR DESCRIPTION
This PR introduces default parameter values that objects can specify directly in their definition. For example, to define a lens with optional external shear `g1`, `g2` that is zero by default:

```cl
params
{
    { "x",  POSITION_X },
    { "y",  POSITION_Y },
    { "r",  RADIUS     },
    { "g1", PARAMETER, UNBOUNDED, -0.0f },
    { "g2", PARAMETER, UNBOUNDED, -0.0f }
};
```

The parameters `g1` and `g2` have a default fixed prior with a value of `0` attached to them.

As seen above, the syntax of the parameter definition was extended by a fourth field for the default value:

    { <name>, <type>, <bounds>, <default> }

The `<bounds>` can be given as before using the lower and upper values `{<lower>, <upper>}` or via one of the new shorthand keywords `UNBOUNDED`, `POS_BOUND`, `NEG_BOUND`.

Because fields beyond the name are optional, giving a value of `0` to the default value will result in it not being detected as set. Therefore, it is necessary to give negative zero `-0.0f` if the value should vanish by default.