### PR TITLE
bugfix: use parameter map to get correct wraparound flag

### DIFF
--- a/src/lensed.c
+++ b/src/lensed.c
@@ -1166,7 +1166,7 @@ int main(int argc, char* argv[])
         if(!wrap)
             errori(NULL);
         for(size_t i = 0; i < lensed->npars; ++i)
-            wrap[i] = lensed->pars[i]->wrap;
+            wrap[i] = lensed->pars[lensed->pmap[i]]->wrap;
         
         // mute MultiNest when necessary
         if(LOG_LEVEL == LOG_QUIET || LOG_LEVEL == LOG_BATCH)


### PR DESCRIPTION
After the derived parameters where implemented in #204, the wrap specification was not taken from the correct parameter (the parameter mapping between MultiNest and Lensed was not used).