### PR TITLE
travis: build releases with XPA support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,15 @@ before_deploy:
   sudo make install &&
   if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ldconfig; fi &&
   popd
+- pushd /tmp &&
+  curl -L https://github.com/ericmandel/xpa/archive/master.tar.gz | tar xz &&
+  cd xpa-master &&
+  ./configure --without-x --without-tcl &&
+  make &&
+  sudo make install &&
+  popd
 - make distclean
-- make
+- make XPA=1
 - make release
 deploy:
   provider: releases


### PR DESCRIPTION
This lets us provide binary releases of Lensed that can talk to DS9 over XPA.