### PR TITLE
boolean options can be set as flags

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -90,12 +90,8 @@ void read_arg(const char* arg, input* inp)
         if(arg[sep] == '=')
             break;
     
-    // error if no equal sign was found
-    if(sep == end)
-        error("option \"--%s\" should be in the form \"--<name>=<value>\"", arg, arg);
-    
     // get option value
-    val = arg + sep + 1;
+    val = arg + sep + ((sep < end) ? 1 : 0);
     
     // try to parse option
     int err = read_option_n(inp, arg, sep, val);

--- a/src/input/options.c
+++ b/src/input/options.c
@@ -288,11 +288,21 @@ int read_option_n(input* inp, const char* name, int n, const char* value)
         return 1;
     }
     
-    // error if no value was given
+    // check if no value was given
     if(!value || !*value)
     {
-        snprintf(ERROR_MSG, sizeof(ERROR_MSG)-1, "option %.*s: no value given", n, name);
-        return 1;
+        // booleans do not need value
+        if(OPTIONS[opt].read == option_read_bool)
+        {
+            // enable boolean flag
+            value = "true";
+        }
+        else
+        {
+            // error, no value given
+            snprintf(ERROR_MSG, sizeof(ERROR_MSG)-1, "option %.*s: no value given", n, name);
+            return 1;
+        }
     }
     
     // try to read option and return eventual errors


### PR DESCRIPTION
This PR makes it easier to give boolean flags, which don't require `=true` to be set, i.e. `lensed --ds9 --resume` (see #220).