### PR TITLE
FITS extension names and weight map output

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -37,10 +37,10 @@ void read_mask(const char* filename, size_t width, size_t height, int** mask);
 void read_psf(const char* filename, size_t* width, size_t* height, cl_float** psf);
 
 // write output to FITS file
-void write_output(const char* filename, size_t width, size_t height, size_t noutput, cl_float* output[]);
+void write_output(const char* filename, size_t width, size_t height, size_t noutput, cl_float* output[], const char* names[]);
 
 // write output to in-memory FITS
-size_t write_memory(void** mem, size_t width, size_t height, size_t noutput, cl_float* output[]);
+size_t write_memory(void** mem, size_t width, size_t height, size_t noutput, cl_float* output[], const char* names[]);
 
 // find most common value
 void find_mode(size_t nvalues, const cl_float values[], const cl_float mask[], double* mode, double* fwhm);

--- a/src/nested.c
+++ b/src/nested.c
@@ -150,7 +150,8 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
     cl_float* residuals;
     cl_float* relerr;
     
-    cl_float* output[4] = {0};
+    cl_float* output[5] = {0};
+    const char* names[5] = {0};
     
     // copy parameters to results
     for(size_t i = 0; i < lensed->npars; ++i)
@@ -233,10 +234,18 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
         output[1] = residuals;
         output[2] = value_map;
         output[3] = relerr;
+        output[4] = lensed->weight;
+        
+        // output extension names
+        names[0] = "IMG";
+        names[1] = "RES";
+        names[2] = "RAW";
+        names[3] = "ERR";
+        names[4] = "WHT";
         
         // write output to FITS if asked to
         if(lensed->fits)
-            write_output(lensed->fits, lensed->width, lensed->height, 4, output);
+            write_output(lensed->fits, lensed->width, lensed->height, 5, output, names);
         
 #ifdef LENSED_XPA
         // send output to DS9 if asked to
@@ -256,7 +265,7 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
             snprintf(frame, 64, "frame %d", lensed->ds9_frame);
             
             // write FITS
-            len = write_memory(&fits, lensed->width, lensed->height, 4, output);
+            len = write_memory(&fits, lensed->width, lensed->height, 5, output, names);
             
             // set the image array
             XPASet(lensed->xpa, lensed->ds9, frame, XPA_MODE, NULL, 0, NULL, NULL, 1);


### PR DESCRIPTION
This PR gives names to the individual FITS extensions that Lensed outputs and adds a new extension that prints the weight map used in the reconstruction.

The image extensions now written are the following:

1. `IMG`, the reconstructed image,
2. `RES`, the residuals of the reconstruction,
3. `RAW`, the raw model pixels before application of a PSF,
4. `ERR`, error estimates from the pixel integration, and
5. `WHT`, the weight map used for the reconstruction.

Furthermore, there is an empty primary HDU that records the version of Lensed used to create the file, and the date the file was generated. It would be possible to store more information there, e.g. the input configuration used for the reconstruction.