### PR TITLE
bugfix when XPA is enabled but DS9 is not

### DIFF
--- a/src/lensed.c
+++ b/src/lensed.c
@@ -1199,11 +1199,14 @@ int main(int argc, char* argv[])
     else
     {
         verbose("  DS9 disabled");
+        
+        // don't use ds9
+        lensed->ds9 = NULL;
     }
 #else
     // XPA is not supported
     lensed->xpa = NULL;
-    lensed->ds9 = 0;
+    lensed->ds9 = NULL;
 #endif
     
     


### PR DESCRIPTION
DS9 was not explicitly disabled when the `--ds9` flag was not set, leading to potential crashes.