### PR TITLE
own implementation file for DS9 integration (compatibility)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ HEADERS = lensed.h \
           path.h \
           profile.h \
           log.h \
+          ds9.h \
           input/objects.h \
           input/options.h \
           input/ini.h \
@@ -104,6 +105,7 @@ SOURCES = lensed.c \
           path.c \
           profile.c \
           log.c \
+          ds9.c \
           input/objects.c \
           input/options.c \
           input/ini.c \

--- a/src/ds9.c
+++ b/src/ds9.c
@@ -1,0 +1,123 @@
+// provide POSIX standard in strict C99 mode
+#define _XOPEN_SOURCE 600
+
+#include <stdlib.h>
+
+#ifdef LENSED_XPA
+
+#include <sys/select.h>
+#include "xpa.h"
+
+#include "ds9.h"
+#include "log.h"
+
+struct ds9_conn
+{
+    void* handle;
+    char* tmpl;
+    int frame;
+};
+
+void* ds9_connect(char* tmpl)
+{
+    // XPA connection handle
+    void* handle;
+    
+    // XPA response
+    char* buf = NULL;
+    size_t len = 0;
+    
+    // create persistent XPA handle
+    handle = XPAOpen(NULL);
+    if(!handle)
+        return NULL;
+    
+    // new DS9 connection object
+    struct ds9_conn* ds9 = malloc(sizeof(struct ds9_conn));
+    if(!ds9)
+        errori(NULL);
+    
+    // store handle and template
+    ds9->handle = handle;
+    ds9->tmpl = tmpl;
+    
+    // create frame for images
+    XPASet(handle, tmpl, "frame new", NULL, NULL, 0, NULL, NULL, 1);
+    
+    // get newly created frame
+    XPAGet(handle, tmpl, "frame", NULL, &buf, &len, NULL, NULL, 1);
+    if(buf)
+        ds9->frame = atoi(buf);
+    else
+        ds9->frame = 999;
+    
+    // free response buffer
+    free(buf);
+    
+    // return DS9 connection
+    return ds9;
+}
+
+void ds9_disconnect(void* p)
+{
+    struct ds9_conn* ds9 = p;
+    XPAClose(ds9->handle);
+    free(ds9);
+}
+
+const char* ds9_template(void* p)
+{
+    struct ds9_conn* ds9 = p;
+    return ds9->tmpl;
+}
+
+int ds9_frame(void* p)
+{
+    struct ds9_conn* ds9 = p;
+    return ds9->frame;
+}
+
+void ds9_mecube(void* p, void* fits, size_t len)
+{
+    struct ds9_conn* ds9 = p;
+    
+    // buffer for frame number
+    char frame[64];
+    
+    // the XPA mode
+    char* mode = "ack=false,verify=false,doxpa=false";
+    
+    // create DS9 frame paramlist
+    snprintf(frame, 64, "frame %d", ds9->frame);
+    
+    // set the image array
+    XPASet(ds9->handle, ds9->tmpl, frame, mode, NULL, 0, NULL, NULL, 1);
+    XPASet(ds9->handle, ds9->tmpl, "mecube", mode, fits, len, NULL, NULL, 1);
+}
+
+#else
+
+void* ds9_connect(char* tmpl)
+{
+    return NULL;
+}
+
+void ds9_disconnect(void* p)
+{
+}
+
+const char* ds9_template(void* p)
+{
+    return NULL;
+}
+
+int ds9_frame(void* p)
+{
+    return 0;
+}
+
+void ds9_mecube(void* p, void* fits, size_t len)
+{
+}
+
+#endif

--- a/src/ds9.h
+++ b/src/ds9.h
@@ -1,0 +1,16 @@
+#pragma once
+
+// connect to a DS9 instance via XPA
+void* ds9_connect(char* tmpl);
+
+// disconnect from a DS9 instance
+void ds9_disconnect(void* ds9);
+
+// get template name from DS9 connection
+const char* ds9_template(void* ds9);
+
+// get frame number from DS9 connection
+int ds9_frame(void* ds9);
+
+// show FITS cube in DS9
+void ds9_mecube(void* ds9, void* fits, size_t len);

--- a/src/lensed.h
+++ b/src/lensed.h
@@ -67,8 +67,6 @@ struct lensed
         profile* unmap_loglike_mem;
     }* profile;
     
-    // XPA handle and settings
-    void* xpa;
-    char* ds9;
-    int ds9_frame;
+    // DS9 connection
+    void* ds9;
 };


### PR DESCRIPTION
This PR implements the DS9 integration in its own source file, which can make sure that the correct POSIX standard is used so that XPA compiles on all platforms.

Has the added benefit that there are muss less `#ifdef LENSED_XPA` throughout the code.