### PR TITLE
7-sigma bounds instead of INF for normal prior

### DIFF
--- a/src/prior/norm.c
+++ b/src/prior/norm.c
@@ -83,10 +83,14 @@ double prior_apply_norm(const void* data, double u)
 
 double prior_lower_norm(const void* data)
 {
-    return -HUGE_VAL;
+    const struct norm* norm = data;
+    
+    return -7*norm->s;
 }
 
 double prior_upper_norm(const void* data)
 {
-    return +HUGE_VAL;
+    const struct norm* norm = data;
+    
+    return +7*norm->s;
 }


### PR DESCRIPTION
This PR makes the `norm` prior report 7 sigma as its bounds instead of infinity. This prevents nagging warnings when a small normal prior is used for bounded parameters such as radii.