### PR TITLE
default values of zero for sky gradient

### DIFF
--- a/objects/sky.cl
+++ b/objects/sky.cl
@@ -3,8 +3,8 @@ type = FOREGROUND;
 params
 {
     { "bg" },
-    { "dx" },
-    { "dy" }
+    { "dx", PARAMETER, UNBOUNDED, -0.0f },
+    { "dy", PARAMETER, UNBOUNDED, -0.0f }
 };
 
 data


### PR DESCRIPTION
This PR sets default values (see #209) of `0` for the sky gradient `dx`, `dy`. This means that these priors do not always have to be specified.

cc @fabiobg83 