### PR TITLE
centre norm prior range on mean

### DIFF
--- a/src/prior/norm.c
+++ b/src/prior/norm.c
@@ -85,12 +85,12 @@ double prior_lower_norm(const void* data)
 {
     const struct norm* norm = data;
     
-    return -7*norm->s;
+    return norm->m - 7*norm->s;
 }
 
 double prior_upper_norm(const void* data)
 {
     const struct norm* norm = data;
     
-    return +7*norm->s;
+    return norm->m + 7*norm->s;
 }


### PR DESCRIPTION
This PR fixes the 7-sigma bounds introduced in #235 to be centred on the mean, instead of zero.