### PR TITLE
use region files for mask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,15 @@ before_deploy:
   make &&
   sudo make install &&
   popd
+- pushd /tmp &&
+  curl -L https://github.com/ericmandel/regions/archive/master.tar.gz | tar xz &&
+  cd regions-master &&
+  ./configure &&
+  make &&
+  sudo make install &&
+  popd
 - make distclean
-- make XPA=1
+- make XPA=1 REGIONS=1
 - make release
 deploy:
   provider: releases

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,21 @@
 #   XPA_LIB                                                          #
 #     XPA library (e.g. `-lxpa`)                                     #
 #                                                                    #
+#   REGIONS                                                          #
+#     build with support for region files                            #
+#                                                                    #
+#   REGIONS_DIR                                                      #
+#     path to a local regions library build                          #
+#                                                                    #
+#   REGIONS_INCLUDE_DIR                                              #
+#     path to `regions.h`                                            #
+#                                                                    #
+#   REGIONS_LIB_DIR                                                  #
+#     path to the regions library                                    #
+#                                                                    #
+#   REGIONS_LIB                                                      #
+#     regions library (e.g. `-lregions`)                             #
+#                                                                    #
 #   OPENCL_DIR                                                       #
 #     path to the OpenCL implementation                              #
 #                                                                    #
@@ -211,6 +226,31 @@ LDLIBS += $(XPA_LIB)
 # ifdef XPA
 endif
 
+# build with regions support
+ifdef REGIONS
+
+CFLAGS += -DLENSED_REGIONS
+
+# regions library
+ifndef REGIONS_LIB
+REGIONS_LIB = -lregions
+endif
+
+ifdef REGIONS_DIR
+REGIONS_INCLUDE_DIR = $(REGIONS_DIR)
+REGIONS_LIB_DIR = $(REGIONS_DIR)
+endif
+ifdef REGIONS_INCLUDE_DIR
+CFLAGS += -I$(REGIONS_INCLUDE_DIR)
+endif
+ifdef REGIONS_LIB_DIR
+LDFLAGS += -L$(REGIONS_LIB_DIR) -Wl,-rpath,$(REGIONS_LIB_DIR)
+endif
+LDLIBS += $(REGIONS_LIB)
+
+# ifdef REGIONS
+endif
+
 # system-dependent OpenCL library
 OPENCL_LIB_Linux = -lOpenCL
 OPENCL_LIB_Darwin = -framework OpenCL
@@ -316,6 +356,10 @@ cache:
 	@$(ECHO) "XPA_INCLUDE_DIR = $(XPA_INCLUDE_DIR)" >> $(CACHE)
 	@$(ECHO) "XPA_LIB_DIR = $(XPA_LIB_DIR)" >> $(CACHE)
 	@$(ECHO) "XPA_LIB = $(XPA_LIB)" >> $(CACHE)
+	@$(ECHO) "REGIONS = $(REGIONS)" >> $(CACHE)
+	@$(ECHO) "REGIONS_INCLUDE_DIR = $(REGIONS_INCLUDE_DIR)" >> $(CACHE)
+	@$(ECHO) "REGIONS_LIB_DIR = $(REGIONS_LIB_DIR)" >> $(CACHE)
+	@$(ECHO) "REGIONS_LIB = $(REGIONS_LIB)" >> $(CACHE)
 	@$(ECHO) "OPENCL_INCLUDE_DIR = $(OPENCL_INCLUDE_DIR)" >> $(CACHE)
 	@$(ECHO) "OPENCL_LIB_DIR = $(OPENCL_LIB_DIR)" >> $(CACHE)
 	@$(ECHO) "OPENCL_LIB = $(OPENCL_LIB)" >> $(CACHE)

--- a/docs/building.md
+++ b/docs/building.md
@@ -102,6 +102,12 @@ For XPA support and DS9 integration, the
 
 is additionally required.
 
+For region file support, the
+
+-   regions library
+
+is additionally required.
+
 
 Build configuration
 -------------------
@@ -131,6 +137,11 @@ The following variables can be passed to Lensed:
 | `XPA_INCLUDE_DIR`       | path to `xpa.h`                                   |
 | `XPA_LIB_DIR`           | path to the XPA library                           |
 | `XPA_LIB`               | XPA library (e.g. `-lxpa`)                        |
+| `REGIONS`               | build with support for region files               |
+| `REGIONS_DIR`           | path to a local regions library build             |
+| `REGIONS_INCLUDE_DIR`   | path to `regions.h`                               |
+| `REGIONS_LIB_DIR`       | path to the regions library                       |
+| `REGIONS_LIB`           | regions library (e.g. `-lregions`)                |
 | `OPENCL_DIR`            | path to the OpenCL implementation                 |
 | `OPENCL_INCLUDE_DIR`    | path to the `CL/cl.h` header                      |
 | `OPENCL_LIB_DIR`        | path to the OpenCL library                        |
@@ -151,6 +162,14 @@ CFITSIO_LIB = -lcfitsio
 MULTINEST_INCLUDE_DIR = 
 MULTINEST_LIB_DIR = 
 MULTINEST_LIB = -lmultinest
+XPA = 
+XPA_INCLUDE_DIR = 
+XPA_LIB_DIR = 
+XPA_LIB = 
+REGIONS = 
+REGIONS_INCLUDE_DIR = 
+REGIONS_LIB_DIR = 
+REGIONS_LIB = 
 OPENCL_INCLUDE_DIR = 
 OPENCL_LIB_DIR = 
 OPENCL_LIB = -framework OpenCL
@@ -172,6 +191,11 @@ The XPA support and DS9 integration is controlled with the `XPA` symbol. Since
 XPA requires an additional [dependency](dependencies.md#xpa), it is by default
 not supported. Calling `make XPA=1` enables XPA support and DS9 integration.
 The XPA library can be [configured](#xpa) like any other dependency.
+
+The region file support is controlled with the `REGIONS` symbol. Since regions
+require an additional [dependency](dependencies.md#regions), they are by default
+not supported. Calling `make REGIONS=1` enables region file support. The regions
+library can be [configured](#regions) like any other dependency.
 
 The following sections contain further details on configuring the individual
 components of Lensed.
@@ -266,12 +290,46 @@ Alternatively, `XPA_INCLUDE_DIR` and `XPA_LIB_DIR` can be explicitly specified.
 $ make XPA_INCLUDE_DIR="$HOME/headers" XPA_LIB_DIR="$HOME/libraries"
 ```
 
-The default XPA library be linked is `-lxpa`. This can be overridden using the
-`XPA_LIB` flag, either giving a `-l<name>` linker flag or the full path to the
-library.
+The default XPA library to be linked is `-lxpa`. This can be overridden using
+the `XPA_LIB` flag, either giving a `-l<name>` linker flag or the full path to
+the library.
 
 ```sh
 $ make XPA_LIB="$HOME/libraries/my-xpa-lib.a"
+```
+
+
+### Regions
+
+To enable region file support, use the `REGIONS` flag.
+
+```sh
+$ make REGIONS=1
+```
+
+If the regions library has been built from source, the path to the source folder
+can be given to Lensed using the `REGIONS_DIR` variable.
+
+```sh
+$ make REGIONS_DIR="$HOME/regions"
+```
+
+This sets both `REGIONS_INCLUDE_DIR` and `REGIONS_LIB_DIR` to `REGIONS_DIR`, as
+this is where `regions.h` and `libregions` reside by default.
+
+Alternatively, `REGIONS_INCLUDE_DIR` and `REGIONS_LIB_DIR` can be explicitly
+specified.
+
+```sh
+$ make REGIONS_INCLUDE_DIR="$HOME/headers" REGIONS_LIB_DIR="$HOME/libraries"
+```
+
+The default regions library to be linked is `-lregions`. This can be overridden
+using the `REGIONS_LIB` flag, either giving a `-l<name>` linker flag or the full
+path to the library.
+
+```sh
+$ make REGIONS_LIB="$HOME/libraries/my-regions-lib.a"
 ```
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,6 +98,9 @@ Option     | Type           | Description                            | Default
 `ds9`      | `bool`         | Integrate with SAOImage DS9.           | `false`
 `ds9-name` | `string`       | XPA template name for DS9.             | `ds9`
 
+If region file support is enabled in the [build options](building.md), the
+`mask` option can alternatively contain the path to a supported region file.
+
 There are a number of caveats regarding the following options.
 
 ### device

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -15,7 +15,12 @@ dependency on
 
 -   [XPA](#xpa) .
 
-XPA support must be enabled explicitly in the [build options](building.md).
+For region file support, there is a further dependency on the
+
+-   [regions library](#regions) .
+
+XPA and region file support must be enabled explicitly in the
+[build options](building.md).
 
 
 CFITSIO
@@ -208,7 +213,7 @@ is required.
 
 ### Sources
 
-The XPA library and command line tools can be install quickly from the GitHub
+The XPA library and command line tools can be installed quickly from the GitHub
 repository:
 
 ```sh
@@ -246,4 +251,36 @@ XQuartz, even though building from source does not (see above).
 ```sh
 $ brew install homebrew/x11/xpa
 ```
+
+
+Regions
+-------
+
+For region file support, the
+
+- [regions library](https://github.com/ericmandel/regions)
+
+is required.
+
+
+### Sources
+
+The regions library and command line tools can be installed quickly from the
+GitHub repository:
+
+```sh
+$ curl -L https://github.com/ericmandel/regions/archive/master.tar.gz | tar xz
+$ cd regions-master
+$ ./configure  # --prefix=... and other options as necessary
+$ make
+```
+
+If possible, the regions library and command line tools should be installed into
+the system, using
+
+```sh
+$ sudo make install
+```
+
+or similar, depending on the platform at hand.
 

--- a/src/data.h
+++ b/src/data.h
@@ -31,7 +31,7 @@ void make_weight(const cl_float* image, const double* gain, double offset, size_
 void read_xweight(const char* filename, size_t width, size_t height, double** weight);
 
 // read mask from file
-void read_mask(const char* filename, size_t width, size_t height, int** mask);
+void read_mask(const char* maskname, const char* imagename, const pcsdata* pcs, size_t width, size_t height, int** mask);
 
 // read PSF from file
 void read_psf(const char* filename, size_t* width, size_t* height, cl_float** psf);

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -465,7 +465,7 @@ int main(int argc, char* argv[])
         int* mask;
         
         // read mask from file
-        read_mask(inp->opts->mask, lensed->width, lensed->height, &mask);
+        read_mask(inp->opts->mask, inp->opts->image, pcs, lensed->width, lensed->height, &mask);
         
         // mask individual pixels by setting their weight to zero
         for(size_t i = 0; i < lensed->size; ++i)


### PR DESCRIPTION
This PR implements the long-standing idea of #100 to use DS9 region files for masking. It requires the [regions library](https://github.com/ericmandel/regions). Build instructions are provided.