### PR TITLE
output p-value map instead of chi map

### DIFF
--- a/src/nested.c
+++ b/src/nested.c
@@ -147,7 +147,7 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
     cl_float* loglike_map;
     cl_float* residuals;
     cl_float* relerr;
-    cl_float* chi;
+    cl_float* pvalue;
     
     cl_float* output[6] = {0};
     const char* names[6] = {0};
@@ -229,12 +229,12 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
         for(size_t i = 0; i < lensed->size; ++i)
             relerr[i] = error_map[i]/value_map[i];
         
-        // calculate chi values (sqrt of loglike)
-        chi = malloc(lensed->size*sizeof(cl_float));
-        if(!chi)
+        // calculate p-values (1 - CDF of chi^2 loglike)
+        pvalue = malloc(lensed->size*sizeof(cl_float));
+        if(!pvalue)
             errori(NULL);
         for(size_t i = 0; i < lensed->size; ++i)
-            chi[i] = sqrt(loglike_map[i]);
+            pvalue[i] = erfc(sqrt(0.5*loglike_map[i]));
         
         // output layers
         output[0] = image_map;
@@ -242,7 +242,7 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
         output[2] = value_map;
         output[3] = relerr;
         output[4] = lensed->weight;
-        output[5] = chi;
+        output[5] = pvalue;
         
         // output extension names
         names[0] = "IMG";
@@ -250,7 +250,7 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
         names[2] = "RAW";
         names[3] = "ERR";
         names[4] = "WHT";
-        names[5] = "CHI";
+        names[5] = "PVL";
         
         // write output to FITS if asked to
         if(lensed->fits)
@@ -282,7 +282,7 @@ void dumper(int* nsamples, int* nlive, int* npar, double** physlive,
         // free arrays
         free(residuals);
         free(relerr);
-        free(chi);
+        free(pvalue);
     }
     
     // status output


### PR DESCRIPTION
This PR is an update of #244. Instead of the chi-map, a map of the p-values for each pixel is output. This has the advantage that the map now linearly represents the likelihood of each pixel in the reconstruction. Extension 6 is now called `PVL` to reflect the change.

