### PR TITLE
fix homebrew install for cfitsio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ before_install:
   fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
     brew update &&
-    brew install cfitsio;
+    brew tap homebrew/science &&
+    brew install gcc cfitsio;
   fi
 - pushd /tmp &&
   git clone git://github.com/JohannesBuchner/MultiNest.git &&


### PR DESCRIPTION
The homebrew `cfitsio` package has moved to the `homebrew/science` tap.