### PR TITLE
weight, xweight, gain options take file or number

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,8 +69,8 @@ Option     | Type           | Description                            | Default
 `image`    | `path`         | Input image, FITS file in counts/sec.  | 
 `gain`     | `real`, `path` | [Conversion factor to counts.](#gain)  | 
 `offset`   | `real`         | Subtracted flat-field offset.          | `0`
-`weight`   | `path`         | Weight map in 1/(counts/sec)^2.        | `none`
-`xweight`  | `path`         | Extra weight map multiplier.           | `none`
+`weight`   | `real`, `path` | Pixel weights in 1/(counts/sec)^2.     | `none`
+`xweight`  | `real`, `path` | Extra weight map multiplier.           | `none`
 `mask`     | `path`         | Input mask, FITS file.                 | `none`
 `psf`      | `path`         | Point-spread function, FITS file.      | `none`
 `rule`     | `string`       | Rule for numerical integration.        | `g3k7`

--- a/src/data.h
+++ b/src/data.h
@@ -15,20 +15,11 @@ void read_image(const char* filename, size_t* width, size_t* height, cl_float** 
 // read pixel coordinate system from image file
 void read_pcs(const char* filename, pcsdata* pcs);
 
-// read gain from file
-void read_gain(const char* filename, size_t width, size_t height, double** gain);
-
-// uniform gain
-void make_gain(double value, size_t width, size_t height, double** gain);
-
-// read weights from file
-void read_weight(const char* filename, size_t width, size_t height, cl_float** weight);
+// read image from file or set to value
+void read_or_make_image(const char* filename, double value, size_t width, size_t height, cl_float** image);
 
 // generate weights from image, gain and offset
-void make_weight(const cl_float* image, const double* gain, double offset, size_t width, size_t height, cl_float** weight);
-
-// read extra weights from file
-void read_xweight(const char* filename, size_t width, size_t height, double** weight);
+void make_weight(const cl_float* image, const cl_float* gain, double offset, size_t width, size_t height, cl_float** weight);
 
 // read mask from file
 void read_mask(const char* maskname, const char* imagename, const pcsdata* pcs, size_t width, size_t height, int** mask);

--- a/src/input.h
+++ b/src/input.h
@@ -20,6 +20,12 @@ enum
     PAR_POS_ANGLE
 };
 
+// option contains a path or a real
+struct path_or_real {
+    char* file;
+    double value;
+};
+
 // options
 typedef struct
 {
@@ -35,15 +41,12 @@ typedef struct
     
     // data
     char* image;
-    char* weight;
-    char* xweight;
+    struct path_or_real* weight;
+    struct path_or_real* xweight;
     char* mask;
     char* psf;
     double offset;
-    struct gain {
-        char* file;
-        double value;
-    }* gain;
+    struct path_or_real* gain;
     
     // MultiNest
     int nlive;

--- a/src/input/options.c
+++ b/src/input/options.c
@@ -26,7 +26,7 @@ struct option
         int default_int;
         double default_real;
         const char* default_path;
-        struct gain* default_gain;
+        struct path_or_real* default_path_or_real;
     } default_value;
     size_t offset;
     size_t size;
@@ -57,7 +57,7 @@ OPTION_TYPE(bool)
 OPTION_TYPE(int)
 OPTION_TYPE(real)
 OPTION_TYPE(path)
-OPTION_TYPE(gain)
+OPTION_TYPE(path_or_real)
 
 // list of known options
 struct option OPTIONS[] = {
@@ -88,7 +88,7 @@ struct option OPTIONS[] = {
     {
         "gain",
         "Conversion factor to counts",
-        OPTION_REQIFNOT(gain, NULL, weight),
+        OPTION_REQIFNOT(path_or_real, NULL, weight),
         OPTION_FIELD(gain)
     },
     {
@@ -100,13 +100,13 @@ struct option OPTIONS[] = {
     {
         "weight",
         "Weight map in 1/(counts/sec)^2",
-        OPTION_OPTIONAL(path, NULL),
+        OPTION_OPTIONAL(path_or_real, NULL),
         OPTION_FIELD(weight)
     },
     {
         "xweight",
         "Extra weight map multiplier",
-        OPTION_OPTIONAL(path, NULL),
+        OPTION_OPTIONAL(path_or_real, NULL),
         OPTION_FIELD(xweight)
     },
     {
@@ -497,57 +497,57 @@ void option_free_path(void* p)
     free(*str);
 }
 
-int option_read_gain(void* out, const char* in)
+int option_read_path_or_real(void* out, const char* in)
 {
     int err;
-    struct gain** g = out;
+    struct path_or_real** por = out;
     
     // allocate space for struct
-    *g = malloc(sizeof(struct gain));
-    if(!*g)
+    *por = malloc(sizeof(struct path_or_real));
+    if(!*por)
         errori(NULL);
     
     // try to read real
-    err = option_read_real(&(*g)->value, in);
+    err = option_read_real(&(*por)->value, in);
     
     // check if there was a number
     if(!err)
     {
         // no file was given
-        (*g)->file = NULL;
+        (*por)->file = NULL;
         return 0;
     }
     
     // no number was given
-    (*g)->value = 0;
+    (*por)->value = 0;
     
     // read path
-    return option_read_path(&(*g)->file, in);
+    return option_read_path(&(*por)->file, in);
 }
 
-int option_write_gain(char* out, const void* in, size_t n)
+int option_write_path_or_real(char* out, const void* in, size_t n)
 {
-    struct gain* const* g = in;
-    if(!*g)
+    struct path_or_real* const* por = in;
+    if(!*por)
     {
         snprintf(out, n, "%s", "none");
         return 0;
     }
-    if((*g)->file)
-        return option_write_string(out, &(*g)->file, n);
+    if((*por)->file)
+        return option_write_string(out, &(*por)->file, n);
     else
-        return option_write_real(out, &(*g)->value, n);
+        return option_write_real(out, &(*por)->value, n);
 }
 
-void option_free_gain(void* p)
+void option_free_path_or_real(void* p)
 {
-    struct gain** g = p;
-    if(*g)
+    struct path_or_real** por = p;
+    if(*por)
     {
-        if((*g)->file)
-            option_free_path(&(*g)->file);
+        if((*por)->file)
+            option_free_path(&(*por)->file);
         else
-            option_free_real(&(*g)->value);
-        free(*g);
+            option_free_real(&(*por)->value);
+        free(*por);
     }
 }

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -424,18 +424,15 @@ int main(int argc, char* argv[])
     // check if weight map is given
     if(inp->opts->weight)
     {
-        // read weight map from file as it is
-        read_weight(inp->opts->weight, lensed->width, lensed->height, &lensed->weight);
+        // read weight map from file or generate from value
+        read_or_make_image(inp->opts->weight->file, inp->opts->weight->value, lensed->width, lensed->height, &lensed->weight);
     }
     else
     {
-        double* gain;
+        cl_float* gain;
         
         // read gain if given, else make uniform gain map
-        if(inp->opts->gain->file)
-            read_gain(inp->opts->gain->file, lensed->width, lensed->height, &gain);
-        else
-            make_gain(inp->opts->gain->value, lensed->width, lensed->height, &gain);
+        read_or_make_image(inp->opts->gain->file, inp->opts->gain->value, lensed->width, lensed->height, &gain);
         
         // make weight map from image, gain and offset
         make_weight(lensed->image, gain, inp->opts->offset, lensed->width, lensed->height, &lensed->weight);
@@ -446,10 +443,10 @@ int main(int argc, char* argv[])
     // apply extra weights if given
     if(inp->opts->xweight)
     {
-        double* xweight;
+        cl_float* xweight;
         
-        // read extra weight map from file
-        read_xweight(inp->opts->xweight, lensed->width, lensed->height, &xweight);
+        // read extra weight map from file or generate from value
+        read_or_make_image(inp->opts->xweight->file, inp->opts->xweight->value, lensed->width, lensed->height, &xweight);
         
         // multiply extra weights
         for(size_t i = 0; i < lensed->size; ++i)


### PR DESCRIPTION
This PR implements the possibility to specify `weight` or `xweight` directly as a number in the config file (similarly to `gain`, which already could be given as a number or FITS file).