### PR TITLE
travis: use Intel CPU OpenCL drivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,14 @@ branches:
     - /travis-.*/
 before_install:
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-updates main restricted" &&
     sudo apt-get update -qq -y &&
-    sudo apt-get install -qq -y gfortran fglrx opencl-headers libcfitsio3-dev;
+    sudo apt-get install -qq -y gfortran opencl-headers libcfitsio3-dev &&
+    pushd /tmp &&
+    curl http://registrationcenter-download.intel.com/akdlm/irc_nas/9019/opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz | tar xz &&
+    cd opencl_runtime_* &&
+    sed -i "s/ACCEPT_EULA=decline/ACCEPT_EULA=accept/g" silent.cfg &&
+    sudo ./install.sh --silent silent.cfg &&
+    popd;
   fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
     brew update &&

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -153,7 +153,7 @@ static const char SETPIPP_POSDEFL[] =
 static const char OBJHEAD[] =
     "#define type constant int type_%s\n"
     "#define params constant struct param parlst_%s[] = \n"
-    "#define data struct __attribute__ ((aligned (4))) data_%s\n"
+    "#define data struct data_%s\n"
     "#define deflection deflection_%s\n"
     "#define brightness brightness_%s\n"
     "#define foreground foreground_%s\n"

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -730,7 +730,6 @@ int main(int argc, char* argv[])
         // flags for building, zero-terminated
         const char* build_flags[] = {
             "-cl-denorms-are-zero",
-            "-cl-strict-aliasing",
             "-cl-fast-relaxed-math",
             NULL
         };


### PR DESCRIPTION
This PR finally fixes the OpenCL issues when testing with Travis.

This is done by downloading and installing the Intel OpenCL drivers for CPUs instead of the `fglrx` package.

These drivers are more strict in following the OpenCL standards, so a number of fixes have also been included.