### PR TITLE
support for even PSF size

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -351,10 +351,6 @@ void read_psf(const char* filename, size_t* width, size_t* height, cl_float** ps
     // read PSF from FITS file
     read_fits(filename, TFLOAT, width, height, (void**)psf);
     
-    // make PSF has odd number of pixels
-    if(!(*width % 2) || !(*height % 2))
-        errorf(filename, 0, "wrong dimensions %zu x %zu for PSF (should be odd numbers)", *width, *height);
-    
     // normalise PSF
     norm = 0;
     size = (*width)*(*height);

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -875,6 +875,15 @@ int main(int argc, char* argv[])
         pcs4.s[2] = pcs->sx;
         pcs4.s[3] = pcs->sy;
         
+        // fix coordinate system to account for half-pixel offset of even PSF
+        if(psf)
+        {
+            if(psfw%2 == 0)
+                pcs4.s[0] += 0.5;
+            if(psfh%2 == 0)
+                pcs4.s[1] += 0.5;
+        }
+        
         verbose("    kernel");
         
         // render kernel 


### PR DESCRIPTION
This PR adds support for PSFs of even side length.

The main issue was that these PSFs are not centred on a pixel, resulting in an offset in the final model image. The solution implemented here is to simply compute the model before PSF with a half-pixel offset, so that after PSF, the coordinates are in order.