### PR TITLE
new `bscale` option for config file

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -47,6 +47,7 @@ typedef struct
     char* psf;
     double offset;
     struct path_or_real* gain;
+    double bscale;
     
     // MultiNest
     int nlive;

--- a/src/input/options.c
+++ b/src/input/options.c
@@ -98,6 +98,12 @@ struct option OPTIONS[] = {
         OPTION_FIELD(offset)
     },
     {
+        "bscale",
+        "Scale input pixel values",
+        OPTION_OPTIONAL(real, 0),
+        OPTION_FIELD(bscale)
+    },
+    {
         "weight",
         "Weight map in 1/(counts/sec)^2",
         OPTION_OPTIONAL(path_or_real, NULL),

--- a/src/lensed.c
+++ b/src/lensed.c
@@ -421,6 +421,15 @@ int main(int argc, char* argv[])
     verbose("  pixel origin: ( %ld, %ld )", pcs->rx, pcs->ry);
     verbose("  pixel scale: ( %f, %f )", pcs->sx, pcs->sy);
     
+    // apply scale to input pixels if given
+    if(inp->opts->bscale)
+    {
+        for(size_t i = 0; i < lensed->size; ++i)
+            lensed->image[i] *= inp->opts->bscale;
+        
+        verbose("  pixel bscale: %f", inp->opts->bscale);
+    }
+    
     // check if weight map is given
     if(inp->opts->weight)
     {


### PR DESCRIPTION
This PR implements a `bscale` option for the config file that works like the `BSCALE` keyword in the FITS file header (pixel values are multiplied by this value before anything else happens with them).
