### PR TITLE
fix OpenCL 2.0 depreciation warning

### DIFF
--- a/src/opencl.h
+++ b/src/opencl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+// use OpenCL API version 1.0
+#define CL_USE_DEPRECATED_OPENCL_1_0_APIS
+
 // OpenCL headers
 #ifdef __APPLE__
 #include <OpenCL/opencl.h>


### PR DESCRIPTION
This PR fixes the error with OpenCL depreciation warnings (#233).

I had actually made that fix some time ago but apparently forgot to push it here, since I cannot find it anywhere.