### PR TITLE
fix OpenCL 2.0 depreciation warning

### DIFF
--- a/src/opencl.h
+++ b/src/opencl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+// use OpenCL API version 1.0
+#define CL_USE_DEPRECATED_OPENCL_1_0_APIS
+
 // OpenCL headers
 #ifdef __APPLE__
 #include <OpenCL/opencl.h>


### PR DESCRIPTION
This PR tries to fix #256.

There seems to be something wrong with this commit, as this is the third time I try and merge it. Hopefully it works now.